### PR TITLE
fix: show token name instead of protocol for notional amount / margin…

### DIFF
--- a/src/components/interface/PendingTransaction/PendingTransaction.tsx
+++ b/src/components/interface/PendingTransaction/PendingTransaction.tsx
@@ -215,7 +215,7 @@ const PendingTransaction: React.FunctionComponent<PendingTransactionProps> = ({
           }}
         >
           <Typography label="NOTIONAL AMOUNT" variant="body2">
-            {activeTransaction.notional} {amm.protocol}
+            {activeTransaction.notional} {amm.underlyingToken.name}
           </Typography>
         </Box>
         <Box
@@ -224,7 +224,7 @@ const PendingTransaction: React.FunctionComponent<PendingTransactionProps> = ({
           }}
         >
           <Typography label="MARGIN" variant="body2">
-            {activeTransaction.margin} {amm.protocol}
+            {activeTransaction.margin} {amm.underlyingToken.name}
           </Typography>
         </Box>
       </Panel>


### PR DESCRIPTION
fix: show token name instead of protocol for notional amount / margin on pending transaction screen

https://www.notion.so/voltz/UI-USDC-instead-of-aUSDC-Alex-67b208119ca94a11ad7d0593632fe38a