### PR TITLE
fix: improved appearance of SwapInfo component

### DIFF
--- a/src/application/App/components/Trader/components/ConnectedSwapForm/ConnectedSwapForm.tsx
+++ b/src/application/App/components/Trader/components/ConnectedSwapForm/ConnectedSwapForm.tsx
@@ -59,6 +59,7 @@ const ConnectedSwapForm: React.FunctionComponent<ConnectedSwapFormProps> = ({ am
     <AMMProvider amm={amm}>
       <SwapForm
         protocol={amm.protocol}
+        underlyingTokenName={amm.underlyingToken.name}
         fixedApr={amm.fixedApr}
         startDate={amm.startDateTime}
         endDate={amm.endDateTime}

--- a/src/components/interface/SwapForm/SwapForm.tsx
+++ b/src/components/interface/SwapForm/SwapForm.tsx
@@ -18,6 +18,7 @@ import { TraderControls, SwapInfo, SubmitSwapFormButton } from './components';
 export type SwapFormProps = {
   isModifying?: boolean;
   protocol?: string;
+  underlyingTokenName?: string;
   fixedApr?: number;
   startDate?: DateTime;
   endDate?: DateTime;
@@ -38,6 +39,7 @@ export type SwapFormProps = {
 const SwapForm: React.FunctionComponent<SwapFormProps> = ({
   isModifying = false,
   protocol,
+  underlyingTokenName,
   fixedApr,
   startDate,
   endDate,
@@ -87,7 +89,7 @@ const SwapForm: React.FunctionComponent<SwapFormProps> = ({
       sx={{
         marginTop: 12,
         padding: 6,
-        width: (theme) => theme.spacing(80),
+        width: (theme) => theme.spacing(85),
         boxShadow: _boxShadow,
         backgroundColor: "secondary.darken045",
         borderRadius: 2
@@ -144,13 +146,6 @@ const SwapForm: React.FunctionComponent<SwapFormProps> = ({
           marginBottom: (theme) => theme.spacing(4),
         }}
       >
-        <SwapInfo notional={notional} />
-      </Box>
-      <Box
-        sx={{
-          marginBottom: (theme) => theme.spacing(4),
-        }}
-      >
         <MarginAmount
           protocol={protocol}
           defaultMargin={defaultMargin}
@@ -158,6 +153,13 @@ const SwapForm: React.FunctionComponent<SwapFormProps> = ({
           margin={margin}
           onChangeMargin={onChangeMargin}
         />
+      </Box>
+      <Box
+        sx={{
+          marginBottom: (theme) => theme.spacing(4),
+        }}
+      >
+        <SwapInfo notional={notional} underlyingTokenName={underlyingTokenName} />
       </Box>
       <Box sx={{ display: 'flex' }}>
         <SubmitSwapFormButton onSubmit={handleSubmit} />

--- a/src/components/interface/SwapForm/components/SwapInfo/SwapInfo.tsx
+++ b/src/components/interface/SwapForm/components/SwapInfo/SwapInfo.tsx
@@ -3,14 +3,32 @@ import isUndefined from 'lodash/isUndefined';
 
 import { useAMMContext } from '@hooks';
 import { Typography } from '@components/atomic';
+import { IconLabel } from '@components/composite';
+import { Box, SystemStyleObject, Theme } from '@mui/system';
+import colors from '../../../../../theme/colors';
 
 export type SwapInfoProps = {
   notional?: number;
+  underlyingTokenName?: string; 
 };
 
-const SwapInfo: React.FunctionComponent<SwapInfoProps> = ({ notional }) => {
+const SwapInfo: React.FunctionComponent<SwapInfoProps> = ({ notional, underlyingTokenName }) => {
   const { swapInfo } = useAMMContext();
   const { result, loading, call } = swapInfo;
+  const containerStyles: SystemStyleObject<Theme> = {
+    border: `1px solid ${colors.lavenderWeb.darken040}`,
+    borderRadius: (theme) => theme.spacing(1),
+    padding: (theme) => theme.spacing(4),
+  };
+  const rowStyles: SystemStyleObject<Theme> = {
+    display: 'flex',
+    alignItems: 'end',
+    justifyContent: 'space-between',
+    width: '100%',
+  };
+  const valueStyles: SystemStyleObject<Theme> = {
+    whiteSpace: 'nowrap',
+  };
 
   useEffect(() => {
     if (!isUndefined(notional)) {
@@ -20,28 +38,59 @@ const SwapInfo: React.FunctionComponent<SwapInfoProps> = ({ notional }) => {
 
   const renderSwapInfo = () => {
     if (loading) {
-      return 'Loading...';
+      return <Typography agentStyling variant="body2">Loading...</Typography>
     }
 
     if (!result) {
-      return '';
+      return null;
     }
 
     return (
-      <>
-        <Typography agentStyling variant="body2" label="Swap info">
-          Available notional: {((result.availableNotional < 0) ? -result.availableNotional : result.availableNotional).toFixed(2)}
-        </Typography>
-        <Typography agentStyling variant="body2">Estimated slippage: {((result.slippage < 0) ? -result.slippage : result.slippage).toFixed(2)}%</Typography>
-        <Typography agentStyling variant="body2">Fee: {((result.fee < 0) ? -result.fee : result.fee).toFixed(2)} </Typography>
-        <Typography agentStyling variant="body2">
-          Additional margin required: {result.marginRequirement.toFixed(2)}
-        </Typography>
-      </>
+      <Box sx={containerStyles}>
+        <Box sx={rowStyles}>
+          <Typography variant="body2" label={<IconLabel
+          label="trade information"
+          icon="information-circle"
+          info="Trade information"
+        />}>
+            NOTIONAL AVAILABLE:
+          </Typography>
+          <Typography agentStyling variant="body2" sx={valueStyles}>
+            {Math.abs(result.availableNotional).toFixed(2)} {underlyingTokenName}
+          </Typography>
+        </Box>
+
+        <Box sx={rowStyles}>
+          <Typography variant="body2">
+            FEES:
+          </Typography>
+          <Typography agentStyling variant="body2" sx={valueStyles}>
+            {Math.abs(result.fee).toFixed(2)} {underlyingTokenName}
+          </Typography>
+        </Box>
+
+        <Box sx={rowStyles}>
+          <Typography variant="body2">
+            ESTIMATED SLIPPAGE:
+          </Typography>
+          <Typography agentStyling variant="body2" sx={valueStyles}>
+            {Math.abs(result.slippage).toFixed(2)} %
+          </Typography>
+        </Box>
+
+        <Box sx={rowStyles}>
+          <Typography variant="body2">
+            ADDITIONAL MARGIN REQUIRED:
+          </Typography>
+          <Typography agentStyling variant="body2" sx={valueStyles}>
+            {result.marginRequirement.toFixed(2)} {underlyingTokenName}
+          </Typography>
+        </Box>
+      </Box>
     );
   };
 
-  return <Typography agentStyling variant="body2"> {renderSwapInfo()} </Typography>
+  return renderSwapInfo()
 };
 
 export default SwapInfo;


### PR DESCRIPTION
A few notes:
 - The label for the section attaches itself to that first block of text (the Typography component) which isn't great for accessibility. We should fix that at some point.
 - The tooltip for the label needs text adding to it
 - The bottom label will wrap if you input a large figure. The styles I've done handle this reasonably well, but Gerard may want changes.