### PR TITLE
refactor: separated code that converts position query data into Position instances

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -28,6 +28,7 @@ module.exports = {
     config.resolve.alias['@graphql'] = path.resolve(path.dirname(__dirname), 'src/graphql');
     config.resolve.alias['@utilities'] = path.resolve(path.dirname(__dirname), 'src/utilities');
     config.resolve.alias['@routes'] = path.resolve(path.dirname(__dirname), 'src/routes');
+    config.resolve.alias['@factories'] = path.resolve(path.dirname(__dirname), 'src/factories');
     return config;
   },
   features: {

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -304,6 +304,7 @@ module.exports = function (webpackEnv) {
         '@utilities': 'src/utilities',
         '@theme': 'src/theme',
         '@routes': 'src/routes',
+        '@factories': 'src/factories',
         // Allows for better profiling with ReactDevTools
         ...(isEnvProductionProfile && {
           'react-dom$': 'react-dom/profiling',

--- a/src/factories/fcmPositionFactory.ts
+++ b/src/factories/fcmPositionFactory.ts
@@ -1,0 +1,135 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import JSBI from 'jsbi';
+import { GetWalletQuery } from '@graphql'
+import { Position, Token, RateOracle, FCMSwap, FCMUnwind, FCMSettlement } from '@voltz-protocol/v1-sdk';
+import { providers } from 'ethers';
+import { AugmentedAMM } from '@utilities';
+import { Wallet }  from '@components/context';
+
+type FCMPositionQueryData = NonNullable<GetWalletQuery['wallet']>["fcmPositions"][number];
+
+/**
+ * Takes the data received for an FCM position from GetWalletQuery and returns a Position class instance
+ * @param positionData - The data for an FCM position received from the GetWalletQuery graphql query
+ * @param signer - The wallet signer
+ */
+export const FCMPositionFactory = (positionData: FCMPositionQueryData, signer: Wallet['signer']): Position => {
+  const {
+    id: positionId,
+    createdTimestamp: positionCreatedTimestamp,
+    amm: {
+      id: ammId,
+      fcm: {
+        id: fcmAddress
+      },
+      marginEngine: {
+        id: marginEngineAddress
+      },
+      rateOracle: {
+        id: rateOracleAddress,
+        protocolId,
+        token: { id: tokenAddress, name: tokenName, decimals },
+      },
+      tickSpacing,
+      termStartTimestamp,
+      termEndTimestamp,
+      updatedTimestamp: ammUpdatedTimestamp,
+      tick,
+      txCount
+    },
+    owner: { id: ownerAddress },
+    updatedTimestamp: positionUpdatedTimestamp,
+    fixedTokenBalance,
+    variableTokenBalance,
+    isSettled,
+    marginInScaledYieldBearingTokens,
+    fcmSwaps,
+    fcmUnwinds,
+    fcmSettlements
+  } = positionData;
+          
+  return new Position({
+    id: positionId,
+    createdTimestamp: positionCreatedTimestamp as JSBI,
+    updatedTimestamp: positionUpdatedTimestamp as JSBI,
+    fixedTokenBalance: fixedTokenBalance as JSBI,
+    variableTokenBalance: variableTokenBalance as JSBI,
+    isSettled,
+    owner: ownerAddress,
+    amm: new AugmentedAMM({
+      id: ammId,
+      signer,
+      provider: providers.getDefaultProvider(
+        process.env.REACT_APP_DEFAULT_PROVIDER_NETWORK,
+      ),
+      environment: 'KOVAN',
+      rateOracle: new RateOracle({
+        id: rateOracleAddress,
+        protocolId: protocolId as number,
+      }),
+      underlyingToken: new Token({
+        id: tokenAddress,
+        name: tokenName,
+        decimals: decimals as number,
+      }),
+      marginEngineAddress,
+      fcmAddress,
+      updatedTimestamp: ammUpdatedTimestamp as JSBI,
+      termStartTimestamp: termStartTimestamp as JSBI,
+      termEndTimestamp: termEndTimestamp as JSBI,
+      tick: parseInt(tick as string),
+      tickSpacing: parseInt(tickSpacing as string),
+      txCount: parseInt(txCount as string),
+      
+    }),
+    marginInScaledYieldBearingTokens: marginInScaledYieldBearingTokens as JSBI,
+    fcmSwaps: fcmSwaps.map((args) => new FCMSwap({
+      id: args.id,
+      transactionId: args.transaction.id,
+      transactionTimestamp: args.transaction.createdTimestamp as JSBI,
+      ammId,
+      fcmPositionId: positionId,
+      desiredNotional: args.desiredNotional as JSBI,
+      sqrtPriceLimitX96: args.sqrtPriceLimitX96 as JSBI,
+      cumulativeFeeIncurred: args.cumulativeFeeIncurred as JSBI,
+      fixedTokenDelta: args.fixedTokenDelta as JSBI,
+      variableTokenDelta: args.variableTokenDelta as JSBI,
+      fixedTokenDeltaUnbalanced: args.fixedTokenDeltaUnbalanced as JSBI
+    })),
+    fcmUnwinds: fcmUnwinds.map((args) => new FCMUnwind({
+      id: args.id,
+      transactionId: args.transaction.id,
+      transactionTimestamp: args.transaction.createdTimestamp as JSBI,
+      ammId,
+      fcmPositionId: positionId,
+      desiredNotional: args.desiredNotional as JSBI,
+      sqrtPriceLimitX96: args.sqrtPriceLimitX96 as JSBI,
+      cumulativeFeeIncurred: args.cumulativeFeeIncurred as JSBI,
+      fixedTokenDelta: args.fixedTokenDelta as JSBI,
+      variableTokenDelta: args.variableTokenDelta as JSBI,
+      fixedTokenDeltaUnbalanced: args.fixedTokenDeltaUnbalanced as JSBI
+    })),
+    fcmSettlements: fcmSettlements.map((args) => new FCMSettlement({
+      id: args.id,
+      transactionId: args.transaction.id,
+      transactionTimestamp: args.transaction.createdTimestamp as JSBI,
+      ammId,
+      fcmPositionId: positionId,
+      settlementCashflow: args.settlementCashflow as JSBI
+    })),
+    swaps: [],
+    mints: [],
+    burns: [],
+    marginUpdates: [],
+    settlements: [],
+    liquidations: [],
+    liquidity: JSBI.BigInt(0),
+    accumulatedFees: JSBI.BigInt(0),
+    positionType: 1,
+    tickLower: 0,
+    tickUpper: 0,
+    margin: JSBI.BigInt(0),
+    source: "FCM",
+  });
+};

--- a/src/factories/index.ts
+++ b/src/factories/index.ts
@@ -1,0 +1,2 @@
+export * from './fcmPositionFactory';
+export * from './mePositionFactory';

--- a/src/factories/mePositionFactory.ts
+++ b/src/factories/mePositionFactory.ts
@@ -1,0 +1,164 @@
+  /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import JSBI from 'jsbi';
+import { GetWalletQuery } from '@graphql'
+import { providers } from 'ethers';
+import { Position, Token, RateOracle, Mint, Burn, Swap, MarginUpdate, Liquidation, Settlement } from '@voltz-protocol/v1-sdk';
+import { AugmentedAMM } from '@utilities';
+import { Wallet }  from '@components/context';
+
+type MEPositionQueryData = NonNullable<GetWalletQuery['wallet']>["positions"][number];
+
+/**
+ * Takes the data received for an ME position from GetWalletQuery and returns a Position class instance
+ * @param positionData - The data for a ME position received from the GetWalletQuery graphql query
+ * @param signer - The wallet signer
+ */
+export const MEPositionFactory = (positionData: MEPositionQueryData, signer: Wallet['signer']): Position => {
+  const {
+    id: positionId,
+    createdTimestamp: positionCreatedTimestamp,
+    amm: {
+      id: ammId,
+      fcm: {
+        id: fcmAddress
+      },
+      marginEngine: {
+        id: marginEngineAddress
+      },
+      rateOracle: {
+        id: rateOracleAddress,
+        protocolId,
+        token: { id: tokenAddress, name: tokenName, decimals },
+      },
+      tickSpacing,
+      termStartTimestamp,
+      termEndTimestamp,
+      updatedTimestamp: ammUpdatedTimestamp,
+      tick,
+      txCount
+    },
+    owner: { id: ownerAddress },
+    tickLower,
+    tickUpper,
+    updatedTimestamp: positionUpdatedTimestamp,
+    liquidity,
+    margin,
+    fixedTokenBalance,
+    variableTokenBalance,
+    accumulatedFees,
+    positionType,
+    isSettled,
+    mints,
+    burns,
+    swaps,
+    marginUpdates,
+    liquidations,
+    settlements
+  } = positionData;
+
+  return new Position({
+    id: positionId,
+    createdTimestamp: positionCreatedTimestamp as JSBI,
+    updatedTimestamp: positionUpdatedTimestamp as JSBI,
+    tickLower: parseInt(tickLower as string),
+    tickUpper: parseInt(tickUpper as string),
+    liquidity: liquidity as JSBI,
+    margin: margin as JSBI,
+    fixedTokenBalance: fixedTokenBalance as JSBI,
+    variableTokenBalance: variableTokenBalance as JSBI,
+    accumulatedFees: accumulatedFees as JSBI,
+    positionType: parseInt(positionType as string),
+    isSettled,
+    owner: ownerAddress,
+    amm: new AugmentedAMM({
+      id: ammId,
+      signer,
+      provider: providers.getDefaultProvider(
+        process.env.REACT_APP_DEFAULT_PROVIDER_NETWORK,
+      ),
+      environment: 'KOVAN',
+      rateOracle: new RateOracle({
+        id: rateOracleAddress,
+        protocolId: protocolId as number,
+      }),
+      underlyingToken: new Token({
+        id: tokenAddress,
+        name: tokenName,
+        decimals: decimals as number,
+      }),
+      marginEngineAddress,
+      fcmAddress,
+      updatedTimestamp: ammUpdatedTimestamp as JSBI,
+      termStartTimestamp: termStartTimestamp as JSBI,
+      termEndTimestamp: termEndTimestamp as JSBI,
+      tick: parseInt(tick as string),
+      tickSpacing: parseInt(tickSpacing as string),
+      txCount: parseInt(txCount as string),
+    }),
+    mints: mints.map((args) => new Mint({
+      id: args.id,
+      transactionId: args.transaction.id,
+      transactionTimestamp: args.transaction.createdTimestamp as JSBI,
+      ammId,
+      positionId: positionId,
+      sender: args.sender,
+      amount: args.amount as JSBI,
+    })),
+    burns: burns.map((args) => new Burn({
+      id: args.id,
+      transactionId: args.transaction.id,
+      transactionTimestamp: args.transaction.createdTimestamp as JSBI,
+      ammId,
+      positionId: positionId,
+      sender: args.sender,
+      amount: args.amount as JSBI,
+    })),
+    swaps: swaps.map((args) => new Swap({
+      id: args.id,
+      transactionId: args.transaction.id,
+      transactionTimestamp: args.transaction.createdTimestamp as JSBI,
+      ammId,
+      positionId: positionId,
+      sender: args.sender,
+      desiredNotional: args.desiredNotional as JSBI,
+      sqrtPriceLimitX96: args.sqrtPriceLimitX96 as JSBI,
+      cumulativeFeeIncurred: args.cumulativeFeeIncurred as JSBI,
+      fixedTokenDelta: args.fixedTokenDelta as JSBI,
+      variableTokenDelta: args.variableTokenDelta as JSBI,
+      fixedTokenDeltaUnbalanced: args.fixedTokenDeltaUnbalanced as JSBI
+    })),
+    marginUpdates: marginUpdates.map((args) => new MarginUpdate({
+      id: args.id,
+      transactionId: args.transaction.id,
+      transactionTimestamp: args.transaction.createdTimestamp as JSBI,
+      ammId,
+      positionId: positionId,
+      depositer: args.depositer ,
+      marginDelta: args.marginDelta as JSBI
+    })),
+    liquidations: liquidations.map((args) => new Liquidation({
+      id: args.id,
+      transactionId: args.transaction.id,
+      transactionTimestamp: args.transaction.createdTimestamp as JSBI,
+      ammId,
+      positionId: positionId,
+      liquidator: args.liquidator,
+      reward: args.reward as JSBI,
+      notionalUnwound: args.notionalUnwound as JSBI,
+    })),
+    settlements: settlements.map((args) => new Settlement({
+      id: args.id,
+      transactionId: args.transaction.id,
+      transactionTimestamp: args.transaction.createdTimestamp as JSBI,
+      ammId,
+      positionId: positionId,
+      settlementCashflow: args.settlementCashflow as JSBI
+    })),
+    fcmSwaps: [],
+    fcmUnwinds: [],
+    fcmSettlements: [],
+    marginInScaledYieldBearingTokens: JSBI.BigInt(0),
+    source: "ME",
+  });
+}

--- a/src/hooks/usePositions.ts
+++ b/src/hooks/usePositions.ts
@@ -1,14 +1,13 @@
 import JSBI from 'jsbi';
 import { useMemo, useEffect } from 'react';
 import isNull from 'lodash/isNull';
-import { Position, Token, RateOracle, Mint, Burn, Swap, MarginUpdate, Liquidation, Settlement, FCMSwap, FCMUnwind, FCMSettlement } from '@voltz-protocol/v1-sdk';
-import { providers } from 'ethers';
+import { Position } from '@voltz-protocol/v1-sdk';
 import { DateTime } from 'luxon';
 
-import { AugmentedAMM } from '@utilities';
 import { actions, selectors } from '@store';
 import { useAgent, useWallet, useSelector, useDispatch } from '@hooks';
 import { Agents } from '@components/contexts';
+import { FCMPositionFactory, MEPositionFactory } from '@factories';
 
 export type usePositionsResult = {
   positions?: Position[];
@@ -26,278 +25,16 @@ const usePositions = (): usePositionsResult => {
 
   const fcmPositions = useMemo(() => {
     if (wallet && wallet.fcmPositions && !loading && !error) {
-      return wallet.fcmPositions.map(
-        ({
-          id: positionId,
-          createdTimestamp: positionCreatedTimestamp,
-          amm: {
-            id: ammId,
-            fcm: {
-              id: fcmAddress
-            },
-            marginEngine: {
-              id: marginEngineAddress
-            },
-            rateOracle: {
-              id: rateOracleAddress,
-              protocolId,
-              token: { id: tokenAddress, name: tokenName, decimals },
-            },
-            tickSpacing,
-            termStartTimestamp,
-            termEndTimestamp,
-            updatedTimestamp: ammUpdatedTimestamp,
-            tick,
-            txCount
-          },
-          owner: { id: ownerAddress },
-          updatedTimestamp: positionUpdatedTimestamp,
-          fixedTokenBalance,
-          variableTokenBalance,
-          isSettled,
-          marginInScaledYieldBearingTokens,
-          fcmSwaps,
-          fcmUnwinds,
-          fcmSettlements
-        }) =>
-          new Position({
-            id: positionId,
-            createdTimestamp: positionCreatedTimestamp as JSBI,
-            updatedTimestamp: positionUpdatedTimestamp as JSBI,
-            fixedTokenBalance: fixedTokenBalance as JSBI,
-            variableTokenBalance: variableTokenBalance as JSBI,
-            isSettled,
-            owner: ownerAddress,
-            amm: new AugmentedAMM({
-              id: ammId,
-              signer,
-              provider: providers.getDefaultProvider(
-                process.env.REACT_APP_DEFAULT_PROVIDER_NETWORK,
-              ),
-              environment: 'KOVAN',
-              rateOracle: new RateOracle({
-                id: rateOracleAddress,
-                protocolId: protocolId as number,
-              }),
-              underlyingToken: new Token({
-                id: tokenAddress,
-                name: tokenName,
-                decimals: decimals as number,
-              }),
-              marginEngineAddress,
-              fcmAddress,
-              updatedTimestamp: ammUpdatedTimestamp as JSBI,
-              termStartTimestamp: termStartTimestamp as JSBI,
-              termEndTimestamp: termEndTimestamp as JSBI,
-              tick: parseInt(tick as string),
-              tickSpacing: parseInt(tickSpacing as string),
-              txCount: parseInt(txCount as string),
-              
-            }),
-            marginInScaledYieldBearingTokens: marginInScaledYieldBearingTokens as JSBI,
-            fcmSwaps: fcmSwaps.map((args) => new FCMSwap({
-              id: args.id,
-              transactionId: args.transaction.id,
-              transactionTimestamp: args.transaction.createdTimestamp as JSBI,
-              ammId,
-              fcmPositionId: positionId,
-              desiredNotional: args.desiredNotional as JSBI,
-              sqrtPriceLimitX96: args.sqrtPriceLimitX96 as JSBI,
-              cumulativeFeeIncurred: args.cumulativeFeeIncurred as JSBI,
-              fixedTokenDelta: args.fixedTokenDelta as JSBI,
-              variableTokenDelta: args.variableTokenDelta as JSBI,
-              fixedTokenDeltaUnbalanced: args.fixedTokenDeltaUnbalanced as JSBI
-            })),
-            fcmUnwinds: fcmUnwinds.map((args) => new FCMUnwind({
-              id: args.id,
-              transactionId: args.transaction.id,
-              transactionTimestamp: args.transaction.createdTimestamp as JSBI,
-              ammId,
-              fcmPositionId: positionId,
-              desiredNotional: args.desiredNotional as JSBI,
-              sqrtPriceLimitX96: args.sqrtPriceLimitX96 as JSBI,
-              cumulativeFeeIncurred: args.cumulativeFeeIncurred as JSBI,
-              fixedTokenDelta: args.fixedTokenDelta as JSBI,
-              variableTokenDelta: args.variableTokenDelta as JSBI,
-              fixedTokenDeltaUnbalanced: args.fixedTokenDeltaUnbalanced as JSBI
-            })),
-            fcmSettlements: fcmSettlements.map((args) => new FCMSettlement({
-              id: args.id,
-              transactionId: args.transaction.id,
-              transactionTimestamp: args.transaction.createdTimestamp as JSBI,
-              ammId,
-              fcmPositionId: positionId,
-              settlementCashflow: args.settlementCashflow as JSBI
-            })),
-            swaps: [],
-            mints: [],
-            burns: [],
-            marginUpdates: [],
-            settlements: [],
-            liquidations: [],
-            liquidity: JSBI.BigInt(0),
-            accumulatedFees: JSBI.BigInt(0),
-            positionType: 1,
-            tickLower: 0,
-            tickUpper: 0,
-            margin: JSBI.BigInt(0),
-            source: "FCM",
-          }),
-      );
+      return wallet.fcmPositions.map(positionData => FCMPositionFactory(positionData, signer));
     }
   }, [fcmPositionCount, loading, error, isSignerAvailable]);
 
   const mePositions = useMemo(() => {
     if (wallet && wallet.positions && !loading && !error) {
-      return wallet.positions.map(
-        ({
-          id: positionId,
-          createdTimestamp: positionCreatedTimestamp,
-          amm: {
-            id: ammId,
-            fcm: {
-              id: fcmAddress
-            },
-            marginEngine: {
-              id: marginEngineAddress
-            },
-            rateOracle: {
-              id: rateOracleAddress,
-              protocolId,
-              token: { id: tokenAddress, name: tokenName, decimals },
-            },
-            tickSpacing,
-            termStartTimestamp,
-            termEndTimestamp,
-            updatedTimestamp: ammUpdatedTimestamp,
-            tick,
-            txCount
-          },
-          owner: { id: ownerAddress },
-          tickLower,
-          tickUpper,
-          updatedTimestamp: positionUpdatedTimestamp,
-          liquidity,
-          margin,
-          fixedTokenBalance,
-          variableTokenBalance,
-          accumulatedFees,
-          positionType,
-          isSettled,
-          mints,
-          burns,
-          swaps,
-          marginUpdates,
-          liquidations,
-          settlements
-        }) =>
-          new Position({
-            id: positionId,
-            createdTimestamp: positionCreatedTimestamp as JSBI,
-            updatedTimestamp: positionUpdatedTimestamp as JSBI,
-            tickLower: parseInt(tickLower as string),
-            tickUpper: parseInt(tickUpper as string),
-            liquidity: liquidity as JSBI,
-            margin: margin as JSBI,
-            fixedTokenBalance: fixedTokenBalance as JSBI,
-            variableTokenBalance: variableTokenBalance as JSBI,
-            accumulatedFees: accumulatedFees as JSBI,
-            positionType: parseInt(positionType as string),
-            isSettled,
-            owner: ownerAddress,
-            amm: new AugmentedAMM({
-              id: ammId,
-              signer,
-              provider: providers.getDefaultProvider(
-                process.env.REACT_APP_DEFAULT_PROVIDER_NETWORK,
-              ),
-              environment: 'KOVAN',
-              rateOracle: new RateOracle({
-                id: rateOracleAddress,
-                protocolId: protocolId as number,
-              }),
-              underlyingToken: new Token({
-                id: tokenAddress,
-                name: tokenName,
-                decimals: decimals as number,
-              }),
-              marginEngineAddress,
-              fcmAddress,
-              updatedTimestamp: ammUpdatedTimestamp as JSBI,
-              termStartTimestamp: termStartTimestamp as JSBI,
-              termEndTimestamp: termEndTimestamp as JSBI,
-              tick: parseInt(tick as string),
-              tickSpacing: parseInt(tickSpacing as string),
-              txCount: parseInt(txCount as string),
-            }),
-            mints: mints.map((args) => new Mint({
-              id: args.id,
-              transactionId: args.transaction.id,
-              transactionTimestamp: args.transaction.createdTimestamp as JSBI,
-              ammId,
-              positionId: positionId,
-              sender: args.sender,
-              amount: args.amount as JSBI,
-            })),
-            burns: burns.map((args) => new Burn({
-              id: args.id,
-              transactionId: args.transaction.id,
-              transactionTimestamp: args.transaction.createdTimestamp as JSBI,
-              ammId,
-              positionId: positionId,
-              sender: args.sender,
-              amount: args.amount as JSBI,
-            })),
-            swaps: swaps.map((args) => new Swap({
-              id: args.id,
-              transactionId: args.transaction.id,
-              transactionTimestamp: args.transaction.createdTimestamp as JSBI,
-              ammId,
-              positionId: positionId,
-              sender: args.sender,
-              desiredNotional: args.desiredNotional as JSBI,
-              sqrtPriceLimitX96: args.sqrtPriceLimitX96 as JSBI,
-              cumulativeFeeIncurred: args.cumulativeFeeIncurred as JSBI,
-              fixedTokenDelta: args.fixedTokenDelta as JSBI,
-              variableTokenDelta: args.variableTokenDelta as JSBI,
-              fixedTokenDeltaUnbalanced: args.fixedTokenDeltaUnbalanced as JSBI
-            })),
-            marginUpdates: marginUpdates.map((args) => new MarginUpdate({
-              id: args.id,
-              transactionId: args.transaction.id,
-              transactionTimestamp: args.transaction.createdTimestamp as JSBI,
-              ammId,
-              positionId: positionId,
-              depositer: args.depositer ,
-              marginDelta: args.marginDelta as JSBI
-            })),
-            liquidations: liquidations.map((args) => new Liquidation({
-              id: args.id,
-              transactionId: args.transaction.id,
-              transactionTimestamp: args.transaction.createdTimestamp as JSBI,
-              ammId,
-              positionId: positionId,
-              liquidator: args.liquidator,
-              reward: args.reward as JSBI,
-              notionalUnwound: args.notionalUnwound as JSBI,
-            })),
-            settlements: settlements.map((args) => new Settlement({
-              id: args.id,
-              transactionId: args.transaction.id,
-              transactionTimestamp: args.transaction.createdTimestamp as JSBI,
-              ammId,
-              positionId: positionId,
-              settlementCashflow: args.settlementCashflow as JSBI
-            })),
-            fcmSwaps: [],
-            fcmUnwinds: [],
-            fcmSettlements: [],
-            marginInScaledYieldBearingTokens: JSBI.BigInt(0),
-            source: "ME",
-          }),
-      );
+      return wallet.positions.map(positionData => MEPositionFactory(positionData, signer));
     }
   }, [positionCount, loading, error, isSignerAvailable]);
+
   const positions = (mePositions) ? ((fcmPositions) ? mePositions.concat(fcmPositions) : mePositions) : fcmPositions;
   if (positions) {
     positions.sort((a, b) => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -18,7 +18,8 @@
       "@store": ["src/store"],
       "@graphql": ["src/graphql"],
       "@utilities": ["src/utilities"],
-      "@routes": ["src/routes"]
+      "@routes": ["src/routes"],
+      "@factories": ["src/factories"],
     },
     "resolveJsonModule": true,
     "allowJs": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,8 @@
       "@store": ["src/store"],
       "@graphql": ["src/graphql"],
       "@utilities": ["src/utilities"],
-      "@routes": ["src/routes"]
+      "@routes": ["src/routes"],
+      "@factories": ["src/factories"],
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */


### PR DESCRIPTION
The `usePositions` hook was doing too much, making it really long and hard to read. I've moved the code that converts the position query data into the Position instances into separate factory files.