### PR TITLE
fix: update margin, leverage box, notional and margin units

### DIFF
--- a/src/components/composite/ProtocolInformation/ProtocolInformation.tsx
+++ b/src/components/composite/ProtocolInformation/ProtocolInformation.tsx
@@ -26,7 +26,7 @@ const ProtocolInformation: React.FunctionComponent<ProtocolInformationProps> = (
       }}
     >
       <Typography
-        label={<IconLabel label="pool" icon="information-circle" info="The underlying yield bearing token." />} // add the wEth tooltip copy here as well
+        label={<IconLabel label="pool" icon="information-circle" info="Trade rates in the stETH pool by depositing ETH as margin. stETH cannot be used as a form of margin until post-merge." />} // add the wEth tooltip copy here as well
         variant="h3"
       >
         {protocol}

--- a/src/components/composite/ProtocolInformation/ProtocolInformation.tsx
+++ b/src/components/composite/ProtocolInformation/ProtocolInformation.tsx
@@ -26,7 +26,7 @@ const ProtocolInformation: React.FunctionComponent<ProtocolInformationProps> = (
       }}
     >
       <Typography
-        label={<IconLabel label="pool" icon="information-circle" info="The underlying yield bearing token." removeIcon />}
+        label={<IconLabel label="pool" icon="information-circle" info="The underlying yield bearing token." />} // add the wEth tooltip copy here as well
         variant="h3"
       >
         {protocol}

--- a/src/components/composite/ProtocolInformation/ProtocolInformation.tsx
+++ b/src/components/composite/ProtocolInformation/ProtocolInformation.tsx
@@ -26,7 +26,7 @@ const ProtocolInformation: React.FunctionComponent<ProtocolInformationProps> = (
       }}
     >
       <Typography
-        label={<IconLabel label="pool" icon="information-circle" info="Trade rates in the stETH pool by depositing ETH as margin. stETH cannot be used as a form of margin until post-merge." />} // add the wEth tooltip copy here as well
+        label={<IconLabel label="pool" icon="information-circle" info="Trade rates in the stETH pool by depositing ETH as margin. stETH cannot be used as a form of margin until post-merge." />}
         variant="h3"
       >
         {protocol}

--- a/src/components/interface/PendingTransaction/PendingTransaction.tsx
+++ b/src/components/interface/PendingTransaction/PendingTransaction.tsx
@@ -45,8 +45,8 @@ const PendingTransaction: React.FunctionComponent<PendingTransactionProps> = ({
 
   let transactionLink: string | undefined = undefined;
   if (activeTransaction.txid) {
-    if (process.env.REACT_APP_REQUIRED_ETHEREUM_NETWORK === 'kovan') {
-      transactionLink = `https://kovan.etherscan.io/tx/${activeTransaction.txid}`
+    if (process.env.REACT_APP_REQUIRED_ETHEREUM_NETWORK === 'goerli') {
+      transactionLink = `https://goerli.etherscan.io/tx/${activeTransaction.txid}`
     }
 
     if (process.env.REACT_APP_REQUIRED_ETHEREUM_NETWORK === 'homestead') {

--- a/src/components/interface/PositionTable/components/PositionTableRow/PositionTableRow.tsx
+++ b/src/components/interface/PositionTable/components/PositionTableRow/PositionTableRow.tsx
@@ -50,7 +50,7 @@ const PositionTableRow: React.FunctionComponent<PositionTableRowProps> = ({
   }
 
   const renderTableCell = (field: string, label: string) => {
-    const token = position.amm.protocol;
+    const underlyingTokenName = position.amm.underlyingToken.name; // Introduced this so margin and notional show the correct underlying token unit e.g. Eth not stEth, USDC not aUSDC
     
     if (field === 'accruedRates') {
       return (<AccruedRates position={position} positionInfo={positionInfo} />);
@@ -65,7 +65,7 @@ const PositionTableRow: React.FunctionComponent<PositionTableRowProps> = ({
         <CurrentMargin 
           accruedCashflow={positionInfo?.accruedCashflow} 
           margin={positionInfo?.margin} 
-          token={position.source.includes("FCM") ? position.amm.protocol : token} 
+          token={position.source.includes("FCM") ? position.amm.protocol : underlyingTokenName || ''} 
           onSelect={handleEditMargin} 
           marginEdit={position.source.includes("FCM") ? false : true}
         />
@@ -80,7 +80,7 @@ const PositionTableRow: React.FunctionComponent<PositionTableRowProps> = ({
       return (
         <Notional 
           notional={agent === Agents.LIQUIDITY_PROVIDER ? position.notional.toFixed(2) : Math.abs(position.effectiveVariableTokenBalance).toFixed(2)} 
-          token={token}
+          token={underlyingTokenName || ''}
           onEdit={agent === Agents.LIQUIDITY_PROVIDER ? handleEditNotional : undefined}
         />
       )

--- a/src/components/interface/SwapForm/components/Leverage/Leverage.tsx
+++ b/src/components/interface/SwapForm/components/Leverage/Leverage.tsx
@@ -19,7 +19,7 @@ export type LeverageProps = {
 
 const Leverage = ({minMargin, notional, onChange, value}: LeverageProps) => {
   const delay = 50;
-  const hint = 'todo';
+  const hint = 'todo'; // add the tooltip copy here
   const margin = isNumber(minMargin) ? Math.max(minMargin, 0.1) : undefined;
 
   const isDisabled = isUndefined(margin) || isUndefined(notional);
@@ -76,8 +76,8 @@ const Leverage = ({minMargin, notional, onChange, value}: LeverageProps) => {
           label={<IconLabel label={'Leverage'} icon="information-circle" info={hint} />}
           value={internalValue}
           onChange={handleChangeInput}
-          suffix='X'
-          suffixPadding={20}
+          suffix='x'
+          suffixPadding={0}
         />
       </Box>
       <Box sx={{ flexGrow: '1', marginLeft: (theme) => theme.spacing(4), display: 'flex', alignItems: 'center' }}>

--- a/src/components/interface/SwapForm/components/Leverage/Leverage.tsx
+++ b/src/components/interface/SwapForm/components/Leverage/Leverage.tsx
@@ -19,7 +19,7 @@ export type LeverageProps = {
 
 const Leverage = ({minMargin, notional, onChange, value}: LeverageProps) => {
   const delay = 50;
-  const hint = 'Choose the amount of leverage you wish to trade with. The slider helps demonstrate safe amounts of leverage.'; // add the tooltip copy here
+  const hint = 'Choose the amount of leverage you wish to trade with. The slider helps demonstrate safe amounts of leverage.';
   const margin = isNumber(minMargin) ? Math.max(minMargin, 0.1) : undefined;
 
   const isDisabled = isUndefined(margin) || isUndefined(notional);

--- a/src/components/interface/SwapForm/components/Leverage/Leverage.tsx
+++ b/src/components/interface/SwapForm/components/Leverage/Leverage.tsx
@@ -19,7 +19,7 @@ export type LeverageProps = {
 
 const Leverage = ({minMargin, notional, onChange, value}: LeverageProps) => {
   const delay = 50;
-  const hint = 'todo'; // add the tooltip copy here
+  const hint = 'Choose the amount of leverage you wish to trade with. The slider helps demonstrate safe amounts of leverage.'; // add the tooltip copy here
   const margin = isNumber(minMargin) ? Math.max(minMargin, 0.1) : undefined;
 
   const isDisabled = isUndefined(margin) || isUndefined(notional);

--- a/src/store/utilities/createId.ts
+++ b/src/store/utilities/createId.ts
@@ -3,7 +3,7 @@ import { Transaction } from '../types';
 const createId = (transaction: Omit<Transaction, 'id'>): string => {
   const fixedLow = (transaction.fixedLow || '').toString();
   const fixedHigh = (transaction.fixedHigh || '').toString();
-  const notional = transaction.notional.toString();
+  const notional = (transaction.notional || '').toString();
   const margin = transaction.margin.toString();
 
   return `${transaction.ammId}${fixedLow}${fixedHigh}${notional}${margin}`;


### PR DESCRIPTION
Update margin now works
Leverage box next to slider now shows 5 digits + comma
Notional and margin in portfolio positions now show correct underlying token next to the value.
Put in placeholder for tooltips for stETH and leverage info circles. 