### PR TITLE
feat: remove periphery env variable

### DIFF
--- a/src/factories/fcmPositionFactory.ts
+++ b/src/factories/fcmPositionFactory.ts
@@ -78,7 +78,6 @@ export const FCMPositionFactory = (positionData: FCMPositionQueryData, signer: W
         decimals: decimals as number,
       }),
       factoryAddress: process.env.REACT_APP_FACTORY_ADDRESS || "0x",
-      peripheryAddress: process.env.REACT_APP_PERIPHERY_ADDRESS || "0x",
       marginEngineAddress,
       fcmAddress,
       updatedTimestamp: JSBI.BigInt(ammUpdatedTimestamp),

--- a/src/factories/mePositionFactory.ts
+++ b/src/factories/mePositionFactory.ts
@@ -92,7 +92,6 @@ export const MEPositionFactory = (positionData: MEPositionQueryData, signer: Wal
         decimals: decimals as number,
       }),
       factoryAddress: process.env.REACT_APP_FACTORY_ADDRESS || "0x",
-      peripheryAddress: process.env.REACT_APP_PERIPHERY_ADDRESS || "0x",
       marginEngineAddress,
       fcmAddress,
       updatedTimestamp: JSBI.BigInt(ammUpdatedTimestamp),

--- a/src/hooks/useAMMs.ts
+++ b/src/hooks/useAMMs.ts
@@ -69,7 +69,6 @@ const useAMMs = (): UseAMMsResult => {
               decimals: decimals as number,
             }),
             factoryAddress: process.env.REACT_APP_FACTORY_ADDRESS || "0x",
-            peripheryAddress: process.env.REACT_APP_PERIPHERY_ADDRESS || "0x",
             marginEngineAddress,
             fcmAddress,
             updatedTimestamp: ammUpdatedTimestamp as JSBI,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -43,7 +43,6 @@ export type SerializedAMM = {
   id: string;
   updatedTimestamp: string;
   factoryAddress: string;
-  peripheryAddress: string;
   fcmAddress: string;
   marginEngineAddress: string;
   termStartTimestamp: string;

--- a/src/store/utilities/deserializeAmm.ts
+++ b/src/store/utilities/deserializeAmm.ts
@@ -13,7 +13,6 @@ const deserializeAmm = (
     id,
     updatedTimestamp,
     factoryAddress,
-    peripheryAddress,
     fcmAddress,
     marginEngineAddress,
     termStartTimestamp,
@@ -41,7 +40,6 @@ const deserializeAmm = (
     tick: parseInt(tick, 10),
     tickSpacing: parseInt(tickSpacing, 10),
     factoryAddress: factoryAddress || "0x",
-    peripheryAddress: peripheryAddress || "0x",
     marginEngineAddress,
     rateOracle: new RateOracle({ id: rateOracleAddress, protocolId: parseInt(protocolId, 10) }),
     underlyingToken: new Token({

--- a/src/store/utilities/serializeAmm.ts
+++ b/src/store/utilities/serializeAmm.ts
@@ -5,7 +5,6 @@ const serializeAmm = (amm: AugmentedAMM): SerializedAMM => ({
   id: amm.id,
   updatedTimestamp: amm.updatedTimestamp.toString(),
   factoryAddress: amm.factoryAddress,
-  peripheryAddress: amm.peripheryAddress,
   fcmAddress: amm.fcmAddress,
   marginEngineAddress: amm.marginEngineAddress,
   termStartTimestamp: amm.termEndTimestamp.toString(),


### PR DESCRIPTION
- Remove the periphery env variable
- Periphery contract address should be inferred from the factory contract directly in the SDK now