### PR TITLE
Ir/expected apy max size

### DIFF
--- a/src/components/composite/ExpectedAPY/ExpectedAPY.tsx
+++ b/src/components/composite/ExpectedAPY/ExpectedAPY.tsx
@@ -30,7 +30,21 @@ export const ExpectedAPY = ({ expectedAPY }:ExpectedAPYProps) => {
     }
   }, expectedAPY);
 
-  if(!expectedAPY || !options) return null;
+  const getSelectedOptionValue = (value: string | undefined) => {
+    if (value) {
+      return value.length >= 7 ? '>1,000%' : value+"%";
+    }
+    return '---'
+  }
+
+  const findLabel = (value: unknown) => {
+    if (options){
+      for (const entry of options){
+        if (entry.value === value) return entry.label;
+      }
+    }
+    return '0%'
+  }
 
   return (
     <>
@@ -39,14 +53,16 @@ export const ExpectedAPY = ({ expectedAPY }:ExpectedAPYProps) => {
           display: 'inline-block',
           padding: (theme) => theme.spacing(4), 
           borderRadius: '8px', 
-          background: colors.lavenderWeb.darken045 
+          background: colors.lavenderWeb.darken045,
+          maxWidth: '100px',
+          width: '100px'
         }}>
           <Typography
             variant="h3"
             label={<IconLabel label="Expected APY" icon="information-circle" info="The APY you would get in a scenario in which the variable APY has the selected value until the pool's maturity" />}
             agentStyling
           >
-            {selectedOptionValue ? `${selectedOptionValue}%` : '---'}
+            {getSelectedOptionValue(selectedOptionValue)}
           </Typography>
         </Box>
         <Box sx={{
@@ -55,11 +71,16 @@ export const ExpectedAPY = ({ expectedAPY }:ExpectedAPYProps) => {
           marginLeft: (theme) => theme.spacing(6)
         }}>
           <SelectInput 
-            defaultValue={options[2].value}
+            displayEmpty={true}
+            renderValue={(value) => { 
+              if (value) return <>{findLabel(value)}</>;
+              if (options) return <>{options[2].label}</> 
+              return <>0%</>;
+            }}
             name="ExpectedVariableAPY"
             label={<IconLabel label="Expected Variable APY:" icon="information-circle" info="Select the percentage of the variable APY between now and the end of the pool that you would like to simulate." />} 
             onChange={(event) => handleChangeMoveBy(event.target.value as string)}
-            options={options}
+            options={options ?? []}
             size="small"
             sx={{ width: '90px' }}
           />

--- a/src/components/interface/SwapInfo/SwapInfo.tsx
+++ b/src/components/interface/SwapInfo/SwapInfo.tsx
@@ -49,13 +49,11 @@ const SwapInfo: React.FunctionComponent<SwapInfoProps> = ({
         <ExpectedAPY 
           expectedAPY={expectedApy}
         />
-          {expectedApy && (
             <Box component={'hr'} sx={{ 
               border: 'none',
               borderBottom: `1px solid ${colors.lavenderWeb.darken045}`,
               margin: (theme) => `${theme.spacing(4)} 0`,
             }}/>
-          )}
         </>
       )}
 


### PR DESCRIPTION
- show `>1000%` when expected APY exceeds 1000
- make sure the Expected apy box does't push the dropdown
- add placeholder for dropdown value
- keep expected APY box there with values showing as "---" while loading 