### PR TITLE
Performance optimisation

### DIFF
--- a/src/components/composite/PoolField/PoolField.tsx
+++ b/src/components/composite/PoolField/PoolField.tsx
@@ -19,12 +19,10 @@ export type PoolFieldProps = {
     agent?: Agents;
     protocol: string;
     isBorrowing: boolean;
-    capLoading: boolean;
-    cap: number | void | null;
     isBorrowTable?: boolean;
 }
 
-const PoolField = ({agent, protocol, isBorrowing, capLoading, cap, isBorrowTable}: PoolFieldProps) => {
+const PoolField = ({agent, protocol, isBorrowing, isBorrowTable}: PoolFieldProps) => {
 
   const protocolIcon = () => {
     const prefix = protocol[0];
@@ -79,40 +77,14 @@ const PoolField = ({agent, protocol, isBorrowing, capLoading, cap, isBorrowTable
     }
 
     if (agent === Agents.LIQUIDITY_PROVIDER) {
-      if (capLoading) {
-        return (
-          <CustomPoolField label={getPoolLabel()}>
-            <ProgressBar
-                leftContent={<>{protocolInfo[0]} - {tokenInfo[0]}</>}
-                rightContent={"Loading..."}
-                percentageComplete={0}
-              />
-          </CustomPoolField>
-        );
-      }
-
-      if (!isNumber(cap)) {
-        return (
-          <CustomPoolField label={getPoolLabel()}>
-            <Box sx={{ width: '100%' }}>
-            {renderPool()}
-            </Box>
-          </CustomPoolField>);
-      }
 
       return (
         <CustomPoolField label={getPoolLabel()}>
-          <ProgressBar
-            leftContent={<> 
-            <Box sx={{marginRight:(theme) => theme.spacing(-1), marginBottom: (theme) => theme.spacing(-1)}}> {protocolInfo[1]}</Box>
-            <Box sx={{marginRight:(theme) => theme.spacing(2), marginBottom: (theme) => theme.spacing(-1)}}>{tokenInfo[1]}</Box>
-            {protocolInfo[0]} - {tokenInfo[0]}
-            </>} 
-            rightContent={<>{formatNumber(2)}% CAP</>}
-            percentageComplete={cap}
-          />
-        </CustomPoolField>
-      );
+          <Box sx={{ width: '100%' }}>
+          {renderPool()}
+          </Box>
+        </CustomPoolField>);
+
     }
     else {
       return (

--- a/src/components/composite/ProtocolInformation/ProtocolInformation.tsx
+++ b/src/components/composite/ProtocolInformation/ProtocolInformation.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Box from '@mui/material/Box';
 
 import { ReactComponent as Aave } from '../PoolField/aave-icon.svg';
@@ -23,12 +23,16 @@ export type ProtocolInformationProps = {
   protocol?: string;
   isBorrowForm?: boolean;
   endDate?: DateTime | undefined;
+  variableApy?:number;
+  fixedApr?:number;
 };
 
 const ProtocolInformation: React.FunctionComponent<ProtocolInformationProps> = ({
   protocol,
   isBorrowForm,
-  endDate
+  endDate,
+  variableApy,
+  fixedApr,
 }) => {
   const { amm } = useAMMContext();
   const getPoolLabel = () => (
@@ -43,7 +47,7 @@ const ProtocolInformation: React.FunctionComponent<ProtocolInformationProps> = (
     </>
   );
 
-  const protocolIcon = () => {
+  const protocolIconMemo = useMemo(() => {
     if (protocol) {
       const prefix = protocol[0];
       switch(prefix) {
@@ -54,9 +58,10 @@ const ProtocolInformation: React.FunctionComponent<ProtocolInformationProps> = (
           default: return ['',''];
       }
     }
-  };
+    return ['',''];
+  }, [protocol]);
 
-  const tokenIcon = () => {
+  const tokenIconMemo = useMemo(() => {
     if (protocol) {
       const token = (protocol[0] === 's') ? protocol.substring(2) : protocol.substring(1);
       switch(token) {
@@ -67,10 +72,11 @@ const ProtocolInformation: React.FunctionComponent<ProtocolInformationProps> = (
           default: return ['','']
       }
     }
-  };
+    return ['',''];
+  }, [protocol]);
 
-  const protocolInfo = protocolIcon();
-  const tokenInfo = tokenIcon();
+  const protocolInfo = protocolIconMemo;
+  const tokenInfo = tokenIconMemo;
 
   return (
     <Box
@@ -104,15 +110,15 @@ const ProtocolInformation: React.FunctionComponent<ProtocolInformationProps> = (
 
       {isBorrowForm !== true && 
       <Box sx={{display:'flex', justifyContent: 'space-between', width: '56%'}}>
-        <FixedAPR />
-        <VariableAPY />
+        <FixedAPR fixedApr={fixedApr}/>
+        <VariableAPY variableApy={variableApy}/>
       </Box>
       }
       {isBorrowForm === true && 
         <Box display='flex'> 
           <Box sx={{display:'flex', justifyContent: 'space-between', width: '56%', marginRight: (theme) => theme.spacing(8)}}>
-          <FixedAPR agent={Agents.FIXED_TRADER}/>
-          <VariableAPY agent={Agents.VARIABLE_TRADER}/>
+          <FixedAPR agent={Agents.FIXED_TRADER} fixedApr={fixedApr}/>
+          <VariableAPY agent={Agents.VARIABLE_TRADER} variableApy={variableApy}/>
         </Box>
         <MaturityEndDate endDate={endDate}/>
         </Box>

--- a/src/components/composite/ProtocolInformation/components/FixedAPR/FixedAPR.tsx
+++ b/src/components/composite/ProtocolInformation/components/FixedAPR/FixedAPR.tsx
@@ -6,29 +6,27 @@ import { Typography } from '@components/atomic';
 import { IconLabel } from '@components/composite';
 import { Agents } from '@contexts';
 import { formatNumber } from '@utilities';
+import { isUndefined } from 'lodash';
 
 export type FixedAPRProps = {
   agent?: Agents;
+  fixedApr?: number;
 };
 
-const FixedAPR: React.FunctionComponent<FixedAPRProps> = ({agent}) => {
-  const { fixedApr } = useAMMContext();
-  const { result, loading, call } = fixedApr;
+const FixedAPR: React.FunctionComponent<FixedAPRProps> = ({agent, fixedApr}) => {
+  // const { fixedApr } = useAMMContext();
+  // const { result, loading, call } = fixedApr;
 
-  useEffect(() => {
-    call();
-  }, [call]);
+  // useEffect(() => {
+  //   call();
+  // }, [call]);
 
   const renderValue = () => {
-    if (loading) {
+    if (isUndefined(fixedApr)) {
       return <Box sx={{ fontSize: 18 }}>Loading...</Box>;
     }
 
-    if (!result) {
-      return '0%';
-    }
-
-    return `${formatNumber(result)}%`;
+    return `${formatNumber(fixedApr)}%`;
   };
 
   return (

--- a/src/components/composite/ProtocolInformation/components/VariableAPY/VariableAPY.tsx
+++ b/src/components/composite/ProtocolInformation/components/VariableAPY/VariableAPY.tsx
@@ -6,29 +6,21 @@ import { Typography } from '@components/atomic';
 import IconLabel from '../../../IconLabel/IconLabel';
 import { Agents } from '@contexts';
 import { formatNumber } from '@utilities';
+import { isUndefined } from 'lodash';
 
 export type VariableAPYProps = {
   agent?: Agents;
+  variableApy?: number;
 };
 
-const VariableAPY: React.FunctionComponent<VariableAPYProps> = ({agent}) => {
-  const { variableApy } = useAMMContext();
-  const { result, loading, call } = variableApy;
-
-  useEffect(() => {
-    call();
-  }, [call]);
+const VariableAPY: React.FunctionComponent<VariableAPYProps> = ({agent, variableApy}) => {
 
   const renderValue = () => {
-    if (loading) {
+    if (isUndefined(variableApy)) {
       return <Box sx={{ fontSize: 18 }}>Loading...</Box>;
     }
 
-    if (!result) {
-      return '0%';
-    }
-
-    return `${formatNumber(result * 100)}%`;
+    return `${formatNumber(variableApy * 100)}%`;
   };
 
   return (

--- a/src/components/containers/ConnectedBorrowForm/ConnectedBorrowForm.tsx
+++ b/src/components/containers/ConnectedBorrowForm/ConnectedBorrowForm.tsx
@@ -1,11 +1,11 @@
-import { useAMMs, useDispatch, useSelector } from '@hooks';
+import { useAMMs, useDispatch, usePositions, useSelector } from '@hooks';
 import { routes } from '@routes';
 import { useEffect, useState } from 'react';
 import { actions, selectors } from '@store';
 
 import { useNavigate } from 'react-router-dom';
 import { BorrowForm, PendingTransaction, SwapFormActions, SwapFormModes, SwapInfo, FormPanel } from '@components/interface';
-import { useAMMContext, useBorrowAMMContext, useBorrowFormContext, Agents } from '@contexts';
+import { useAMMContext, useBorrowAMMContext, useBorrowFormContext, Agents, usePositionContext } from '@contexts';
 
 
 export type ConnectedBorrowFormProps = {
@@ -16,6 +16,7 @@ const ConnectedBorrowForm: React.FunctionComponent<ConnectedBorrowFormProps> = (
   const { amm: borrowAmm } = useBorrowAMMContext();
   const { amm } = useAMMContext();
   const form = useBorrowFormContext();
+  const { position } = usePositionContext();
   
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -90,6 +91,7 @@ const ConnectedBorrowForm: React.FunctionComponent<ConnectedBorrowFormProps> = (
     return (
       <PendingTransaction
         amm={amm}
+        position={position}
         isEditingMargin={false}
         isRollover={false}
         transactionId={transactionId}

--- a/src/components/containers/ConnectedBorrowForm/ConnectedBorrowForm.tsx
+++ b/src/components/containers/ConnectedBorrowForm/ConnectedBorrowForm.tsx
@@ -1,6 +1,6 @@
 import { useAMMs, useDispatch, useSelector } from '@hooks';
 import { routes } from '@routes';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { actions, selectors } from '@store';
 
 import { useNavigate } from 'react-router-dom';
@@ -21,6 +21,18 @@ const ConnectedBorrowForm: React.FunctionComponent<ConnectedBorrowFormProps> = (
   const navigate = useNavigate();
   const [transactionId, setTransactionId] = useState<string | undefined>();
   const activeTransaction = useSelector(selectors.transactionSelector)(transactionId);
+
+  const { fixedApr, variableApy } = useAMMContext();
+  const { result: resultFixedApr, loading: loadingFixedApr, call: callFixedApr } = fixedApr;
+  const { result: resultVariableApy, loading: loadingVariableApy, call: callVariableApy } = variableApy;
+
+  useEffect(() => {
+    callFixedApr();
+  }, [callFixedApr]);
+
+  useEffect(() => {
+    callVariableApy();
+  }, [ callVariableApy]);
 
   const protocol = () => {
     if ([5,6].includes(amm.rateOracle.protocolId) ){
@@ -85,6 +97,8 @@ const ConnectedBorrowForm: React.FunctionComponent<ConnectedBorrowFormProps> = (
         notional={form.selectedFixedDebt}
         margin={form.margin}
         onBack={handleGoBack}
+        variableApy={typeof resultVariableApy === 'number' ?  resultVariableApy : undefined}
+        fixedApr={typeof resultFixedApr === 'number' ? resultFixedApr :  undefined}
       />
     );
   }
@@ -117,6 +131,8 @@ const ConnectedBorrowForm: React.FunctionComponent<ConnectedBorrowFormProps> = (
         tradeInfoErrorMessage={form.borrowInfo.errorMessage}
         swapSummaryLoading={form.borrowInfo.loading}
         balance={form.balance}
+        variableApy={typeof resultVariableApy === 'number' ?  resultVariableApy : undefined}
+        fixedApr={typeof resultFixedApr === 'number' ? resultFixedApr :  undefined}
       />
       <SwapInfo
         balance={form.selectedFixedDebt}

--- a/src/components/containers/ConnectedMintBurnForm/ConnectedMintBurnForm.tsx
+++ b/src/components/containers/ConnectedMintBurnForm/ConnectedMintBurnForm.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { routes } from '@routes';
 import { actions, selectors } from '@store';
 import { useAgent, useDispatch, useSelector } from '@hooks';
-import { MintBurnFormActions, MintBurnFormModes, useAMMContext, useMintBurnForm, usePositionContext } from '@contexts';
+import { MintBurnFormActions, MintBurnFormModes, useAMMContext, useAMMsContext, useMintBurnForm, usePositionContext } from '@contexts';
 import { FormPanel, MintBurnCurrentPosition, MintBurnForm, MintBurnInfo, PendingTransaction } from '@components/interface';
 import { updateFixedRate } from './utilities';
 import { Position } from '@voltz-protocol/v1-sdk/dist/types/entities';
@@ -26,9 +26,9 @@ const ConnectedMintBurnForm: React.FunctionComponent<ConnectedMintBurnFormProps>
   const [transactionId, setTransactionId] = useState<string | undefined>();
   const activeTransaction = useSelector(selectors.transactionSelector)(transactionId);
 
-  const { fixedApr, variableApy } = useAMMContext();
-  const { result: resultFixedApr, loading: loadingFixedApr, call: callFixedApr } = fixedApr;
-  const { result: resultVariableApy, loading: loadingVariableApy, call: callVariableApy } = variableApy;
+  const { fixedApr, variableApy } = useAMMsContext();
+  const { result: resultFixedApr, loading: loadingFixedApr, call: callFixedApr } = fixedApr(targetAmm);
+  const { result: resultVariableApy, loading: loadingVariableApy, call: callVariableApy } = variableApy(targetAmm);
 
   useEffect(() => {
     callFixedApr();

--- a/src/components/containers/ConnectedMintBurnForm/ConnectedMintBurnForm.tsx
+++ b/src/components/containers/ConnectedMintBurnForm/ConnectedMintBurnForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { routes } from '@routes';
 import { actions, selectors } from '@store';
@@ -25,6 +25,18 @@ const ConnectedMintBurnForm: React.FunctionComponent<ConnectedMintBurnFormProps>
 
   const [transactionId, setTransactionId] = useState<string | undefined>();
   const activeTransaction = useSelector(selectors.transactionSelector)(transactionId);
+
+  const { fixedApr, variableApy } = useAMMContext();
+  const { result: resultFixedApr, loading: loadingFixedApr, call: callFixedApr } = fixedApr;
+  const { result: resultVariableApy, loading: loadingVariableApy, call: callVariableApy } = variableApy;
+
+  useEffect(() => {
+    callFixedApr();
+  }, [callFixedApr]);
+
+  useEffect(() => {
+    callVariableApy();
+  }, [ callVariableApy]);
 
   const getSubmitReduxAction = () => {
     const transaction = { 
@@ -112,6 +124,8 @@ const ConnectedMintBurnForm: React.FunctionComponent<ConnectedMintBurnFormProps>
         margin={isUndefined(form.state.margin && form.isRemovingMargin) ? 0 : 
           (Math.abs(form.state.margin as number) * (form.isRemovingMargin ? -1 : 1) )}
         onBack={handleGoBack}
+        variableApy={typeof resultVariableApy === 'number' ?  resultVariableApy : undefined}
+        fixedApr={typeof resultFixedApr === 'number' ? resultFixedApr :  undefined}
       />
     );
   }
@@ -140,12 +154,15 @@ const ConnectedMintBurnForm: React.FunctionComponent<ConnectedMintBurnFormProps>
         onChangeMarginAction={form.setMarginAction} 
         onChangeNotional={form.setNotional}
         onSubmit={handleSubmit}
+        protocol={targetAmm.protocol}
         gaButtonId={getPoolButtonId(form.state.marginAction.toString(), form.state.liquidityAction.toString(), "", agent, targetAmm)}
         startDate={targetAmm.startDateTime}
         submitButtonState={form.submitButtonState}
         tokenApprovals={form.tokenApprovals}
         tradeInfoErrorMessage={form.minRequiredMargin.errorMessage}
         underlyingTokenName={targetAmm.underlyingToken.name}
+        variableApy={typeof resultVariableApy === 'number' ?  resultVariableApy : undefined}
+        fixedApr={typeof resultFixedApr === 'number' ? resultFixedApr :  undefined}
       />
       <MintBurnInfo
         balance={form.balance}

--- a/src/components/containers/ConnectedMintBurnForm/ConnectedMintBurnForm.tsx
+++ b/src/components/containers/ConnectedMintBurnForm/ConnectedMintBurnForm.tsx
@@ -115,6 +115,7 @@ const ConnectedMintBurnForm: React.FunctionComponent<ConnectedMintBurnFormProps>
     return (
       <PendingTransaction 
         amm={targetAmm} 
+        position={position}
         isEditingMargin={form.mode === MintBurnFormModes.EDIT_MARGIN} 
         liquidityAction={form.state.liquidityAction} 
         isRollover={form.mode === MintBurnFormModes.ROLLOVER}

--- a/src/components/containers/ConnectedPositionTable/ConnectedPositionTable.tsx
+++ b/src/components/containers/ConnectedPositionTable/ConnectedPositionTable.tsx
@@ -128,7 +128,7 @@ const ConnectedPositionTable: React.FunctionComponent<ConnectedAMMTableProps> = 
           transactionId={positionToSettle.txId}
           onComplete={handleTransactionFinished}
           notional={Math.abs(positionToSettle.position.effectiveVariableTokenBalance)}
-          margin={spData.margin}
+          margin={spData?.margin}
           onBack={handleTransactionFinished}
         />
       </Box>

--- a/src/components/containers/ConnectedPositionTable/ConnectedPositionTable.tsx
+++ b/src/components/containers/ConnectedPositionTable/ConnectedPositionTable.tsx
@@ -5,7 +5,7 @@ import { data } from '@utilities';
 import { usePositions, useSelector, useWallet } from '@hooks';
 import { PendingTransaction, PortfolioHeader, PositionTable, PositionTableFields } from '@components/interface';
 import { Button, Loading, Panel, RouteLink, Typography } from '@components/atomic';
-import { Agents, usePortfolioContext } from '@contexts';
+import { Agents, useAMMContext, useAMMsContext, usePortfolioContext } from '@contexts';
 import { actions, selectors } from '@store';
 import { useDispatch } from '@hooks';
 import { AugmentedAMM } from '@utilities';
@@ -35,7 +35,6 @@ const ConnectedPositionTable: React.FunctionComponent<ConnectedAMMTableProps> = 
   const activeTransaction = useSelector(selectors.transactionSelector)(positionToSettle?.txId); // contains a failureMessage attribute that will contain whatever came out from the sdk
   const dispatch = useDispatch();
 
-  const [positionInformation, setPositionInformation] = useState<Record<Position['id'], PositionInfo>>({});
 
   const portfolioData = usePortfolioContext();
 

--- a/src/components/containers/ConnectedPositionTable/ConnectedPositionTable.tsx
+++ b/src/components/containers/ConnectedPositionTable/ConnectedPositionTable.tsx
@@ -122,6 +122,7 @@ const ConnectedPositionTable: React.FunctionComponent<ConnectedAMMTableProps> = 
       <Box sx={{display: 'flex', justifyContent: 'center'}}>
         <PendingTransaction
           amm={positionToSettle.position.amm as AugmentedAMM}
+          position={positionToSettle.position}
           isEditingMargin={false}
           isSettle={true}
           transactionId={positionToSettle.txId}

--- a/src/components/containers/ConnectedSwapForm/ConnectedSwapForm.tsx
+++ b/src/components/containers/ConnectedSwapForm/ConnectedSwapForm.tsx
@@ -5,7 +5,7 @@ import { routes } from '@routes';
 import { actions, selectors } from '@store';
 import { useAgent, useDispatch, useSelector } from '@hooks';
 import { SwapCurrentPosition, SwapForm, SwapInfo, PendingTransaction, SwapFormActions, FormPanel, SwapFormModes } from '@components/interface';
-import { Agents, useAMMContext, usePositionContext, useSwapFormContext } from '@contexts';
+import { Agents, useAMMContext, useAMMsContext, usePositionContext, useSwapFormContext } from '@contexts';
 import { BigNumber } from 'ethers';
 import { AugmentedAMM, getNotionalActionFromHintState, getPoolButtonId } from '@utilities';
 import { isUndefined } from 'lodash';
@@ -27,9 +27,9 @@ const ConnectedSwapForm: React.FunctionComponent<ConnectedSwapFormProps> = ({ on
   const [transactionId, setTransactionId] = useState<string | undefined>();
   const activeTransaction = useSelector(selectors.transactionSelector)(transactionId); // contains a failureMessage attribute that will contain whatever came out from the sdk
 
-  const { fixedApr, variableApy } = useAMMContext();
-  const { result: resultFixedApr, loading: loadingFixedApr, call: callFixedApr } = fixedApr;
-  const { result: resultVariableApy, loading: loadingVariableApy, call: callVariableApy } = variableApy;
+  const { variableApy, fixedApr } = useAMMsContext()
+  const { result: resultFixedApr, loading: loadingFixedApr, call: callFixedApr } = fixedApr(targetAmm);
+  const { result: resultVariableApy, loading: loadingVariableApy, call: callVariableApy } = variableApy(targetAmm);
 
   useEffect(() => {
     callFixedApr();

--- a/src/components/containers/ConnectedSwapForm/ConnectedSwapForm.tsx
+++ b/src/components/containers/ConnectedSwapForm/ConnectedSwapForm.tsx
@@ -133,6 +133,8 @@ const ConnectedSwapForm: React.FunctionComponent<ConnectedSwapFormProps> = ({ on
             onComplete={handleComplete}
             margin={Math.abs(form.state.margin as number) * (form.isRemovingMargin ? -1 : 1)}
             onBack={handleGoBack}
+            variableApy={typeof resultVariableApy === 'number' ?  resultVariableApy : undefined}
+            fixedApr={typeof resultFixedApr === 'number' ? resultFixedApr :  undefined}
           />
         );
       }
@@ -153,6 +155,8 @@ const ConnectedSwapForm: React.FunctionComponent<ConnectedSwapFormProps> = ({ on
             notional={form.swapInfo.data?.availableNotional}
             margin={Math.abs(form.state.margin as number) * (form.isRemovingMargin ? -1 : 1)}
             onBack={handleGoBack}
+            variableApy={typeof resultVariableApy === 'number' ?  resultVariableApy : undefined}
+            fixedApr={typeof resultFixedApr === 'number' ? resultFixedApr :  undefined}
           />
         );
       }
@@ -171,6 +175,8 @@ const ConnectedSwapForm: React.FunctionComponent<ConnectedSwapFormProps> = ({ on
             notional={form.swapInfo.data?.availableNotional}
             margin={form.swapInfo.data?.marginRequirement}
             onBack={handleGoBack}
+            variableApy={typeof resultVariableApy === 'number' ?  resultVariableApy : undefined}
+            fixedApr={typeof resultFixedApr === 'number' ? resultFixedApr :  undefined}
           />
         );
       }

--- a/src/components/containers/ConnectedSwapForm/ConnectedSwapForm.tsx
+++ b/src/components/containers/ConnectedSwapForm/ConnectedSwapForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { routes } from '@routes';
@@ -26,6 +26,18 @@ const ConnectedSwapForm: React.FunctionComponent<ConnectedSwapFormProps> = ({ on
   const { mode } = form;
   const [transactionId, setTransactionId] = useState<string | undefined>();
   const activeTransaction = useSelector(selectors.transactionSelector)(transactionId); // contains a failureMessage attribute that will contain whatever came out from the sdk
+
+  const { fixedApr, variableApy } = useAMMContext();
+  const { result: resultFixedApr, loading: loadingFixedApr, call: callFixedApr } = fixedApr;
+  const { result: resultVariableApy, loading: loadingVariableApy, call: callVariableApy } = variableApy;
+
+  useEffect(() => {
+    callFixedApr();
+  }, [callFixedApr]);
+
+  useEffect(() => {
+    callVariableApy();
+  }, [ callVariableApy]);
 
   const getReduxAction = () => {
     const transaction = { 
@@ -170,6 +182,8 @@ const ConnectedSwapForm: React.FunctionComponent<ConnectedSwapFormProps> = ({ on
             isFCMUnwind={true}
             notional={form.swapInfo.data?.availableNotional}
             onBack={handleGoBack}
+            variableApy={typeof resultVariableApy === 'number' ?  resultVariableApy : undefined}
+            fixedApr={typeof resultFixedApr === 'number' ? resultFixedApr :  undefined}
           />
         );
       }
@@ -212,6 +226,8 @@ const ConnectedSwapForm: React.FunctionComponent<ConnectedSwapFormProps> = ({ on
         tokenApprovals={form.tokenApprovals}
         tradeInfoErrorMessage={form.swapInfo.errorMessage}
         underlyingTokenName={targetAmm.underlyingToken.name}
+        variableApy={typeof resultVariableApy === 'number' ?  resultVariableApy : undefined}
+        fixedApr={typeof resultFixedApr === 'number' ? resultFixedApr :  undefined}
       />
       <SwapInfo
         balance={form.balance}

--- a/src/components/containers/ConnectedSwapForm/ConnectedSwapForm.tsx
+++ b/src/components/containers/ConnectedSwapForm/ConnectedSwapForm.tsx
@@ -127,6 +127,7 @@ const ConnectedSwapForm: React.FunctionComponent<ConnectedSwapFormProps> = ({ on
         return (
           <PendingTransaction
             amm={targetAmm}
+            position={position}
             isEditingMargin={true}
             transactionId={transactionId}
             onComplete={handleComplete}
@@ -143,6 +144,7 @@ const ConnectedSwapForm: React.FunctionComponent<ConnectedSwapFormProps> = ({ on
         return (
           <PendingTransaction
             amm={targetAmm}
+            position={position}
             isEditingMargin={false}
             showNegativeNotional={form.mode === SwapFormModes.EDIT_NOTIONAL && isRemovingNotional }
             isRollover={form.mode === SwapFormModes.ROLLOVER}
@@ -160,6 +162,7 @@ const ConnectedSwapForm: React.FunctionComponent<ConnectedSwapFormProps> = ({ on
         return (
           <PendingTransaction
             amm={targetAmm}
+            position={position}
             isEditingMargin={false}
             isRollover={form.mode === SwapFormModes.ROLLOVER}
             transactionId={transactionId}
@@ -176,6 +179,7 @@ const ConnectedSwapForm: React.FunctionComponent<ConnectedSwapFormProps> = ({ on
         return (
           <PendingTransaction
             amm={targetAmm}
+            position={position}
             isEditingMargin={false}
             transactionId={transactionId}
             onComplete={handleComplete}

--- a/src/components/interface/AMMTable/components/AMMTableRow/AMMTableRow.tsx
+++ b/src/components/interface/AMMTable/components/AMMTableRow/AMMTableRow.tsx
@@ -26,12 +26,6 @@ const AMMTableRow: React.FunctionComponent<AMMTableRowProps> = ({ datum, index, 
   const wallet = useWallet();
   const { agent } = useAgent();
   const variant = agent === Agents.LIQUIDITY_PROVIDER ? 'darker' : 'main';
-
-  const { ammCaps: { call: loadCap, loading: capLoading, result: cap } } = useAMMContext();
-
-  useEffect(() => {
-    loadCap();
-  }, [loadCap]);
   
   // add object to sx prop
   // todo:
@@ -97,7 +91,7 @@ const AMMTableRow: React.FunctionComponent<AMMTableRowProps> = ({ datum, index, 
             );
           }
 
-          return (<PoolField agent={agent} protocol={datum.protocol} isBorrowing={datum.isBorrowing} capLoading={capLoading} cap={cap}/>);
+          return (<PoolField agent={agent} protocol={datum.protocol} isBorrowing={datum.isBorrowing}/>);
         };
 
         return <TableCell key={field}>{renderDisplay()}</TableCell>;

--- a/src/components/interface/AMMTable/components/AMMTableRow/AMMTableRow.tsx
+++ b/src/components/interface/AMMTable/components/AMMTableRow/AMMTableRow.tsx
@@ -12,7 +12,8 @@ import { useAgent, useWallet } from '@hooks';
 import { AMMTableDatum } from '../../types';
 import { labels } from '../../constants';
 import { VariableAPY, FixedAPR } from './components';
-import { getPoolButtonId, getRowButtonId } from '@utilities';
+import { getRowButtonId } from '@utilities';
+import { isNumber } from 'lodash';
 
 export type AMMTableRowProps = {
   datum: AMMTableDatum;
@@ -26,7 +27,19 @@ const AMMTableRow: React.FunctionComponent<AMMTableRowProps> = ({ datum, index, 
   const wallet = useWallet();
   const { agent } = useAgent();
   const variant = agent === Agents.LIQUIDITY_PROVIDER ? 'darker' : 'main';
+
+  const { variableApy, fixedApr } = useAMMContext();
+  const { result: resultFixedApr, loading : loadingFixedApr, call: callFixedApr } = fixedApr;
+  const { result: resultVarApy, loading: loadingVarApy, call: callVarApy } = variableApy;
   
+  useEffect(() => {
+      callVarApy();
+  }, [callVarApy]);
+
+  useEffect(() => {
+      callFixedApr();
+  }, [callFixedApr]);
+
   // add object to sx prop
   // todo:
   // 
@@ -73,11 +86,11 @@ const AMMTableRow: React.FunctionComponent<AMMTableRowProps> = ({ datum, index, 
       <TableRow key={index} sx={{...typeStyleOverrides() }}>
       {labels.map(([field, label]) => {
         if (field === 'variableApy') {
-          return <VariableAPY />;
+          return <VariableAPY variableApy={isNumber(resultVarApy) ? resultVarApy : undefined}/>;
         }
 
         if (field === 'fixedApr') {
-          return <FixedAPR />;
+          return <FixedAPR fixedApr={isNumber(resultFixedApr) ? resultFixedApr : undefined}/>;
         }
 
         const renderDisplay = () => {

--- a/src/components/interface/AMMTable/components/AMMTableRow/AMMTableRow.tsx
+++ b/src/components/interface/AMMTable/components/AMMTableRow/AMMTableRow.tsx
@@ -4,7 +4,7 @@ import TableCell from '@mui/material/TableCell';
 import { SystemStyleObject, Theme } from '@mui/system';
 import isNull from 'lodash/isNull';
 
-import { Agents } from '@contexts';
+import { Agents, useAMMsContext } from '@contexts';
 import { Button } from '@components/atomic';
 import { PoolField, MaturityInformation } from '@components/composite';
 import { useAMMContext } from '@contexts';
@@ -27,10 +27,11 @@ const AMMTableRow: React.FunctionComponent<AMMTableRowProps> = ({ datum, index, 
   const wallet = useWallet();
   const { agent } = useAgent();
   const variant = agent === Agents.LIQUIDITY_PROVIDER ? 'darker' : 'main';
+  const {amm} = useAMMContext()
 
-  const { variableApy, fixedApr } = useAMMContext();
-  const { result: resultFixedApr, loading : loadingFixedApr, call: callFixedApr } = fixedApr;
-  const { result: resultVarApy, loading: loadingVarApy, call: callVarApy } = variableApy;
+  const { variableApy, fixedApr } = useAMMsContext();
+  const { result: resultFixedApr, loading : loadingFixedApr, call: callFixedApr } = fixedApr(amm);
+  const { result: resultVarApy, loading: loadingVarApy, call: callVarApy } = variableApy(amm);
   
   useEffect(() => {
       callVarApy();

--- a/src/components/interface/AMMTable/components/AMMTableRow/components/FixedAPR/FixedAPR.tsx
+++ b/src/components/interface/AMMTable/components/AMMTableRow/components/FixedAPR/FixedAPR.tsx
@@ -4,25 +4,20 @@ import { useAMMContext } from '@contexts';
 import { Typography } from '@components/atomic';
 import TableCell from '@mui/material/TableCell';
 import { formatNumber } from '@utilities';
+import { isUndefined } from 'lodash';
 
-const FixedAPR: React.FunctionComponent = () => {
-  const { fixedApr } = useAMMContext();
-  const { result, loading, call } = fixedApr;
+export type FixedAPRProps = {
+  fixedApr?: number;
+};
 
-  useEffect(() => {
-    call();
-  }, [call]);
+const FixedAPR: React.FunctionComponent<FixedAPRProps> = ({fixedApr}) => {
 
   const renderValue = () => {
-    if (loading) {
+    if (isUndefined(fixedApr)) {
       return 'Loading...';
     }
 
-    if (!result) {
-      return '0%';
-    }
-
-    return `${formatNumber(result)}%`;
+    return `${formatNumber(fixedApr)}%`;
   };
 
   return (

--- a/src/components/interface/AMMTable/components/AMMTableRow/components/VariableAPY/VariableAPY.tsx
+++ b/src/components/interface/AMMTable/components/AMMTableRow/components/VariableAPY/VariableAPY.tsx
@@ -4,25 +4,21 @@ import TableCell from '@mui/material/TableCell';
 import { useAMMContext } from '@contexts';
 import { Typography } from '@components/atomic';
 import { formatNumber } from '@utilities';
+import { isUndefined } from 'lodash';
 
-const VariableAPY: React.FunctionComponent = () => {
-  const { variableApy } = useAMMContext();
-  const { result, loading, call } = variableApy;
+export type VariableAPYProps = {
+  variableApy?: number;
+};
 
-  useEffect(() => {
-    call();
-  }, [call]);
+
+const VariableAPY: React.FunctionComponent<VariableAPYProps> = ({variableApy}) => {
 
   const renderValue = () => {
-    if (loading) {
+    if (isUndefined(variableApy)) {
       return 'Loading...';
     }
 
-    if (!result) {
-      return '0%';
-    }
-
-    return `${formatNumber(result * 100)}%`;
+    return `${formatNumber(variableApy * 100)}%`;
   };
 
   return (

--- a/src/components/interface/BorrowForm/BorrowForm.tsx
+++ b/src/components/interface/BorrowForm/BorrowForm.tsx
@@ -42,6 +42,8 @@ export type BorrowProps = {
   margin: number;
   swapSummaryLoading: boolean;
   balance: number;
+  variableApy?:number;
+  fixedApr?:number;
 };
 
 const BorrowForm: React.FunctionComponent<BorrowProps> = ({
@@ -68,7 +70,9 @@ const BorrowForm: React.FunctionComponent<BorrowProps> = ({
   submitButtonState,
   margin,
   swapSummaryLoading,
-  balance
+  balance,
+  variableApy,
+  fixedApr,
 }) => {
   const bottomSpacing: SystemStyleObject<Theme> = {
     marginBottom: (theme) => theme.spacing(10)
@@ -91,7 +95,7 @@ const BorrowForm: React.FunctionComponent<BorrowProps> = ({
   return (
     <FormPanel isBorrowForm={true}>
       <Box sx={{marginBottom: (theme) => theme.spacing(8)}}>
-        <ProtocolInformation protocol={protocol} isBorrowForm={true} endDate={endDate}/>
+        <ProtocolInformation protocol={protocol} isBorrowForm={true} endDate={endDate} variableApy={variableApy} fixedApr={fixedApr}/>
       </Box>
 
       <Box sx={{marginBottom: (theme) => theme.spacing(2)}}>

--- a/src/components/interface/BorrowTable/components/BorrowTableRow/BorrowTableRow.tsx
+++ b/src/components/interface/BorrowTable/components/BorrowTableRow/BorrowTableRow.tsx
@@ -157,7 +157,7 @@ const BorrowTableRow: React.FunctionComponent<BorrowTableRowProps> = ({ datum, i
               // modify to show svgs
               return (
               <TableCell key={"protocol"} width="35%" >
-                <PoolField protocol={datum.protocol} isBorrowing={false} capLoading={false} cap={null} isBorrowTable={true}/>
+                <PoolField protocol={datum.protocol} isBorrowing={false} isBorrowTable={true}/>
               </TableCell>);
             }
             if (field === 'maturity') {

--- a/src/components/interface/MintBurnForm/MintBurnForm.tsx
+++ b/src/components/interface/MintBurnForm/MintBurnForm.tsx
@@ -15,11 +15,11 @@ import { MarginControls } from '../SwapForm/components';
 import { useTokenApproval } from '@hooks';
 import { MintBurnFormHintStates, MintBurnFormLiquidityAction, MintBurnFormMarginAction, MintBurnFormModes, MintBurnFormState, MintBurnFormSubmitButtonStates } from '@contexts';
 import { SystemStyleObject, Theme } from '@theme';
+import { FixedAPR } from 'src/components/composite/ProtocolInformation/components';
 
 export type MintBurnFormProps = {
   approvalsNeeded?: boolean;
-  balance?: number; 
-  fixedApr?: number;
+  balance?: number;
   endDate?: DateTime;
   errors: Record<string, string>;
   formState: MintBurnFormState;
@@ -44,6 +44,8 @@ export type MintBurnFormProps = {
   tokenApprovals: ReturnType<typeof useTokenApproval>;
   tradeInfoErrorMessage?: string;
   underlyingTokenName?: string;
+  variableApy?:number;
+  fixedApr?:number;
 };
 
 const MintBurnForm: React.FunctionComponent<MintBurnFormProps> = ({
@@ -72,7 +74,9 @@ const MintBurnForm: React.FunctionComponent<MintBurnFormProps> = ({
   submitButtonState,
   tokenApprovals,
   tradeInfoErrorMessage,
-  underlyingTokenName = ''
+  underlyingTokenName = '',
+  variableApy,
+  fixedApr,
 }) => {
   const bottomSpacing: SystemStyleObject<Theme> = {
     marginBottom: (theme) => theme.spacing(6)
@@ -81,7 +85,7 @@ const MintBurnForm: React.FunctionComponent<MintBurnFormProps> = ({
 
   return (
     <FormPanel boxShadowType='LP'>
-      <ProtocolInformation protocol={protocol} />
+      <ProtocolInformation protocol={protocol} fixedApr={fixedApr} variableApy={variableApy}/>
       <Box sx={bottomSpacing}>
         <MaturityInformation
           label={

--- a/src/components/interface/Page/Page.tsx
+++ b/src/components/interface/Page/Page.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box';
 import { Background } from '@components/atomic';
 import Nav from '../Nav/Nav';
 import WalletConnect from '../WalletConnect/WalletConnect';
+import Workbench from './workbench.svg';
 
 interface PageProps {
   children?: React.ReactNode;
@@ -24,34 +25,9 @@ const Page: React.FunctionComponent<PageProps> = ({ children }: PageProps) => (
       flexGrow: 1, 
       overflowY: 'auto', 
       position: 'relative',
+      backgroundImage: `url(${Workbench})`
     }}>
-      <Box sx={{ width: '100%', position: 'absolute', top: 0, left: 0, backdropFilter: 'blur(8px)', }}>
-        <Box sx={{ 
-          width: 'calc(50% - 720px)', 
-          height: '100%', 
-          position: 'absolute', 
-          top: 0, 
-          left: 0, 
-          background: 'rgba(12, 10, 23, 0.06)'
-        }}/>
-        <Box sx={{ 
-          width: '100%', 
-          margin: '0 auto',
-          maxWidth: '1440px',
-          padding: (theme) => `${theme.spacing(10)} 0 ${theme.spacing(15)}`,
-          background: 'linear-gradient(270deg, rgba(25, 21, 42, 0) 0%, rgba(23, 19, 41, 0.83) 22.92%, #08070E 50.21%, rgba(23, 19, 41, 0.81) 76.81%, rgba(25, 21, 42, 0) 100%)',
-        }}>
-          {children}
-        </Box>
-        <Box sx={{ 
-          width: 'calc(50% - 720px)', 
-          height: '100%', 
-          position: 'absolute', 
-          top: 0, 
-          right: 0, 
-          background: 'rgba(12, 10, 23, 0.06)'
-        }}/>
-      </Box>
+      <Box sx={{ position: 'relative', padding: (theme) => `${theme.spacing(10)} 0 ${theme.spacing(15)}`, }}>{children}</Box>
     </Box>
   </Background>
 );

--- a/src/components/interface/Page/workbench.svg
+++ b/src/components/interface/Page/workbench.svg
@@ -1,0 +1,20 @@
+<svg width="1440" height="856" viewBox="0 0 1440 856" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_b_1921_8268)">
+<rect width="1440" height="856" fill="url(#paint0_linear_1921_8268)"/>
+</g>
+<defs>
+<filter id="filter0_b_1921_8268" x="-8" y="-8" width="1456" height="872" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feGaussianBlur in="BackgroundImage" stdDeviation="4"/>
+<feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur_1921_8268"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur_1921_8268" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear_1921_8268" x1="1440" y1="393.721" x2="-8.65202e-09" y2="393.721" gradientUnits="userSpaceOnUse">
+<stop stop-color="#19152A" stop-opacity="0"/>
+<stop offset="0.229167" stop-color="#171329" stop-opacity="0.83"/>
+<stop offset="0.502083" stop-color="#08070E"/>
+<stop offset="0.768056" stop-color="#171329" stop-opacity="0.81"/>
+<stop offset="1" stop-color="#19152A" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/components/interface/PendingTransaction/PendingTransaction.tsx
+++ b/src/components/interface/PendingTransaction/PendingTransaction.tsx
@@ -52,11 +52,12 @@ const PendingTransaction: React.FunctionComponent<PendingTransactionProps> = ({
 }) => {
   const previousWallet = useRef<Wallet>();
   const [fetch, setFetch] = useState<number>(0);
+  const fetchLimit = 20;
   const { account, refetch, wallet, loading } = useWallet();
   const {agent} = useAgent();
   const { isPositionFeched } = useAMMsContext();
   const activeTransaction = useSelector(selectors.transactionSelector)(transactionId);
-  const isFetched = previousWallet.current ? isPositionFeched(wallet as Wallet, previousWallet.current, position) : undefined;
+  const isFetched = previousWallet.current ? isPositionFeched(wallet as Wallet, previousWallet.current, position) : fetch >= fetchLimit ;
 
   useEffect(() => {
     if (!previousWallet.current && wallet) {
@@ -68,7 +69,7 @@ const PendingTransaction: React.FunctionComponent<PendingTransactionProps> = ({
     if (activeTransaction && (activeTransaction.resolvedAt || activeTransaction.succeededAt)) {
       if( wallet && previousWallet.current && !isPositionFeched(wallet as Wallet, previousWallet.current, position) ) {
         setTimeout(() => {refetch()}, 500);
-        if(fetch < 20) setFetch(fetch+1);
+        if(fetch < fetchLimit) setFetch(fetch+1);
       } 
     }
   }, [activeTransaction?.resolvedAt, activeTransaction?.succeededAt, fetch]);

--- a/src/components/interface/PendingTransaction/PendingTransaction.tsx
+++ b/src/components/interface/PendingTransaction/PendingTransaction.tsx
@@ -25,6 +25,8 @@ export type PendingTransactionProps = {
   margin?: number;
   onBack: () => void;
   onComplete: () => void;
+  variableApy?: number;
+  fixedApr?: number;
 };
 
 const PendingTransaction: React.FunctionComponent<PendingTransactionProps> = ({
@@ -41,6 +43,8 @@ const PendingTransaction: React.FunctionComponent<PendingTransactionProps> = ({
   margin,
   onBack,
   onComplete,
+  variableApy,
+  fixedApr,
 }) => {
   const { account } = useWallet();
   const {agent} = useAgent();
@@ -311,7 +315,7 @@ const PendingTransaction: React.FunctionComponent<PendingTransactionProps> = ({
           )
           : (
             <AMMProvider amm={amm}>
-              <ProtocolInformation protocol={amm.protocol} />
+              <ProtocolInformation protocol={amm.protocol} variableApy={variableApy} fixedApr={fixedApr}/>
             </AMMProvider>
           )
         }

--- a/src/components/interface/PendingTransaction/PendingTransaction.tsx
+++ b/src/components/interface/PendingTransaction/PendingTransaction.tsx
@@ -52,23 +52,11 @@ const PendingTransaction: React.FunctionComponent<PendingTransactionProps> = ({
 }) => {
   const previousWallet = useRef<Wallet>();
   const [fetch, setFetch] = useState<number>(0);
-  const { account, refetch, wallet } = useWallet();
+  const { account, refetch, wallet, loading } = useWallet();
   const {agent} = useAgent();
   const { isPositionFeched } = useAMMsContext();
   const activeTransaction = useSelector(selectors.transactionSelector)(transactionId);
-  // const {fetchSubgraphPosition} = useAMMsContext();
-  // const {result, loading, call} = fetchSubgraphPosition;
-
-  // const { data, loading, error, stopPolling } = useGetWalletQuery({
-  //   variables: { id: account || '' },
-  //   pollInterval,
-  // });
-
-  // useEffect(() => {
-  //   if (activeTransaction && (activeTransaction.resolvedAt || activeTransaction.succeededAt) && !loading && !result) {
-  //     call(position);
-  //   }
-  // }, [activeTransaction?.resolvedAt, activeTransaction?.succeededAt]);
+  const isFetched = previousWallet.current ? isPositionFeched(wallet as Wallet, previousWallet.current, position) : undefined;
 
   useEffect(() => {
     if (!previousWallet.current && wallet) {
@@ -78,12 +66,9 @@ const PendingTransaction: React.FunctionComponent<PendingTransactionProps> = ({
 
   useEffect(() => {
     if (activeTransaction && (activeTransaction.resolvedAt || activeTransaction.succeededAt)) {
-      const current = wallet?.positions[0].burns.length;
-      const previous = previousWallet.current?.positions[0].burns.length;
-      const pos = position?.burns.length;
       if( wallet && previousWallet.current && !isPositionFeched(wallet as Wallet, previousWallet.current, position) ) {
-        refetch();
-        if(fetch < 10) setFetch(fetch+1);
+        setTimeout(() => {refetch()}, 500);
+        if(fetch < 20) setFetch(fetch+1);
       } 
     }
   }, [activeTransaction?.resolvedAt, activeTransaction?.succeededAt, fetch]);
@@ -104,7 +89,7 @@ const PendingTransaction: React.FunctionComponent<PendingTransactionProps> = ({
   }
 
   const renderStatus = () => {
-    if (activeTransaction.resolvedAt) {
+    if (activeTransaction.resolvedAt && isFetched) {
       return (
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
           <Box
@@ -205,7 +190,7 @@ const PendingTransaction: React.FunctionComponent<PendingTransactionProps> = ({
       );
     }
 
-    if (activeTransaction.succeededAt) {
+    if (activeTransaction.succeededAt && isFetched) {
       return (
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
           <Box

--- a/src/components/interface/PositionTable/components/PositionTableRow/PositionTableRow.tsx
+++ b/src/components/interface/PositionTable/components/PositionTableRow/PositionTableRow.tsx
@@ -11,6 +11,7 @@ import { FixedAPR, Notional, CurrentMargin, Maturity, AccruedRates } from './com
 import { useAgent } from '@hooks';
 import { Position, PositionInfo } from '@voltz-protocol/v1-sdk';
 import { formatNumber, isBorrowing } from '@utilities';
+import { isNumber } from 'lodash';
 
 export type PositionTableRowProps = {
   position: Position;
@@ -27,6 +28,13 @@ const PositionTableRow: React.FunctionComponent<PositionTableRowProps> = ({
 }) => {
   const { agent } = useAgent();
   const labels = agent === Agents.LIQUIDITY_PROVIDER ? lpLabels : traderLabels;
+
+  const { fixedApr } = useAMMContext();
+  const { result: resultFixedApr, loading : loadingFixedApr, call: callFixedApr } = fixedApr;
+
+  useEffect(() => {
+      callFixedApr();
+  }, [callFixedApr]);
 
   const typeStyleOverrides: SystemStyleObject<Theme> = {
     backgroundColor: `secondary.darken050`, // this affects the colour of the positions rows in the LP positions 
@@ -49,7 +57,7 @@ const PositionTableRow: React.FunctionComponent<PositionTableRowProps> = ({
     }
 
     if (field === 'fixedApr') {
-      return <FixedAPR />;
+      return <FixedAPR fixedApr={isNumber(resultFixedApr) ? resultFixedApr : undefined}/>;
     }
 
     if (field === 'margin') {

--- a/src/components/interface/PositionTable/components/PositionTableRow/PositionTableRow.tsx
+++ b/src/components/interface/PositionTable/components/PositionTableRow/PositionTableRow.tsx
@@ -28,12 +28,6 @@ const PositionTableRow: React.FunctionComponent<PositionTableRowProps> = ({
   const { agent } = useAgent();
   const labels = agent === Agents.LIQUIDITY_PROVIDER ? lpLabels : traderLabels;
 
-  const { ammCaps: { call: loadCap, loading: capLoading, result: cap } } = useAMMContext();
-
-  useEffect(() => {
-    loadCap();
-  }, [loadCap]);
-
   const typeStyleOverrides: SystemStyleObject<Theme> = {
     backgroundColor: `secondary.darken050`, // this affects the colour of the positions rows in the LP positions 
     borderRadius: 2 
@@ -86,7 +80,7 @@ const PositionTableRow: React.FunctionComponent<PositionTableRowProps> = ({
     
     if (field === 'pool') {
 
-      return (<PoolField agent={agent} protocol={position.amm.protocol} isBorrowing={isBorrowing(position.amm.rateOracle.protocolId)} capLoading={capLoading} cap={cap}/>)      
+      return (<PoolField agent={agent} protocol={position.amm.protocol} isBorrowing={isBorrowing(position.amm.rateOracle.protocolId)}/>)      
     }
 
     if (field === 'rateRange') {

--- a/src/components/interface/PositionTable/components/PositionTableRow/components/FixedAPR/FixedAPR.tsx
+++ b/src/components/interface/PositionTable/components/PositionTableRow/components/FixedAPR/FixedAPR.tsx
@@ -4,25 +4,20 @@ import { useAMMContext } from '@contexts';
 import { Typography } from '@components/atomic';
 import { IconLabel } from '@components/composite';
 import { formatNumber } from '@utilities';
+import { isUndefined } from 'lodash';
 
-const FixedAPR: React.FunctionComponent = () => {
-  const { fixedApr } = useAMMContext();
-  const { result, loading, call } = fixedApr;
+export type FixedAPRProps = {
+  fixedApr?: number;
+};
 
-  useEffect(() => {
-    call();
-  }, [call]);
+const FixedAPR: React.FunctionComponent<FixedAPRProps> = ({fixedApr}) => {
 
   const renderValue = () => {
-    if (loading) {
+    if (isUndefined(fixedApr)) {
       return 'Loading...';
     }
 
-    if (!result) {
-      return '0%';
-    }
-
-    return `${formatNumber(result)}%`;
+    return `${formatNumber(fixedApr)}%`;
   };
 
   return (

--- a/src/components/interface/SwapForm/SwapForm.tsx
+++ b/src/components/interface/SwapForm/SwapForm.tsx
@@ -48,6 +48,8 @@ export type SwapProps = {
   tokenApprovals: ReturnType<typeof useTokenApproval>;
   tradeInfoErrorMessage?: string;
   underlyingTokenName?: string;
+  variableApy?: number;
+  fixedApr?: number;
 };
 
 const Swap: React.FunctionComponent<SwapProps> = ({
@@ -81,6 +83,8 @@ const Swap: React.FunctionComponent<SwapProps> = ({
   tokenApprovals,
   tradeInfoErrorMessage,
   underlyingTokenName,
+  variableApy,
+  fixedApr,
 }) => {
   const { agent, onChangeAgent } = useAgent();
   const bottomSpacing: SystemStyleObject<Theme> = {
@@ -101,7 +105,7 @@ const Swap: React.FunctionComponent<SwapProps> = ({
         </Box>
       )}
 
-      <ProtocolInformation protocol={protocol}/>
+      <ProtocolInformation protocol={protocol} variableApy={variableApy} fixedApr={fixedApr}/>
 
       <Box sx={bottomSpacing}>
         <MaturityInformation

--- a/src/contexts/AMMsContext/AMMsContext.tsx
+++ b/src/contexts/AMMsContext/AMMsContext.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useRef } from 'react';
 import { useAMM, useAsyncFunction, UseAsyncFunctionResult } from '@hooks';
 import { AugmentedAMM } from '@utilities';
 import { createContext, useContext } from 'react'
+import { Position, PositionInfo } from '@voltz-protocol/v1-sdk/dist/types/entities';
 
 export type AMMsProviderProps = {
 };
@@ -9,6 +10,8 @@ export type AMMsProviderProps = {
 export type AMMsContext = {
     variableApy: (amm:AugmentedAMM) => UseAsyncFunctionResult<AugmentedAMM, number | void>;
     fixedApr: (amm:AugmentedAMM) => UseAsyncFunctionResult<AugmentedAMM, number | void>;
+    positionsInfo: Record<string,PositionInfo>;
+    cachePositionInfo: (info: PositionInfo, position: Position) => void;
 }
 
 const AMMsCtx = createContext<AMMsContext>({} as unknown as AMMsContext);
@@ -18,6 +21,12 @@ export const AMMsProvider: React.FunctionComponent<AMMsProviderProps> = ({ child
 
   const variableApys = useRef<Record<string,number>>({});
   const fixedAprs = useRef<Record<string,number>>({});
+
+  const positionsInfo = useRef<Record<string,PositionInfo>>({});
+
+  const cachePositionInfo = (info: PositionInfo, position: Position) => {
+    positionsInfo.current[position.id] = info;
+  }
 
   const useVariableApy = (amm: AugmentedAMM) => (useAsyncFunction(
     async () => {
@@ -51,7 +60,9 @@ export const AMMsProvider: React.FunctionComponent<AMMsProviderProps> = ({ child
 
   const value = {
     variableApy: useVariableApy,
-    fixedApr: useFixedApr
+    fixedApr: useFixedApr,
+    positionsInfo: positionsInfo.current,
+    cachePositionInfo
   };
 
   return <AMMsCtx.Provider value={value}>{children}</AMMsCtx.Provider>;

--- a/src/contexts/AMMsContext/AMMsContext.tsx
+++ b/src/contexts/AMMsContext/AMMsContext.tsx
@@ -1,0 +1,64 @@
+import React, { useMemo, useRef } from 'react';
+import { useAMM, useAsyncFunction, UseAsyncFunctionResult } from '@hooks';
+import { AugmentedAMM } from '@utilities';
+import { createContext, useContext } from 'react'
+
+export type AMMsProviderProps = {
+};
+
+export type AMMsContext = {
+    variableApy: (amm:AugmentedAMM) => UseAsyncFunctionResult<AugmentedAMM, number | void>;
+    fixedApr: (amm:AugmentedAMM) => UseAsyncFunctionResult<AugmentedAMM, number | void>;
+}
+
+const AMMsCtx = createContext<AMMsContext>({} as unknown as AMMsContext);
+AMMsCtx.displayName = 'AMMContext';
+
+export const AMMsProvider: React.FunctionComponent<AMMsProviderProps> = ({ children }) => {
+
+  const variableApys = useRef<Record<string,number>>({});
+  const fixedAprs = useRef<Record<string,number>>({});
+
+  const useVariableApy = (amm: AugmentedAMM) => (useAsyncFunction(
+    async () => {
+      if(variableApys.current[amm.id]) {
+        return variableApys.current[amm.id];
+      }
+      if (amm) {
+        const apy = await amm?.getInstantApy();
+        variableApys.current[amm.id] = apy;
+        return apy;
+      }
+      return 0;
+    },
+    useMemo(() => undefined, []),
+  ));
+
+  const useFixedApr = (amm: AugmentedAMM) => (useAsyncFunction(
+    async () => {
+      if(fixedAprs.current[amm.id]) {
+        return fixedAprs.current[amm.id];
+      }
+      if (amm) {
+        const apy = await amm?.getFixedApr();
+        fixedAprs.current[amm.id] = apy;
+        return apy;
+      }
+      return 0;
+    },
+    useMemo(() => undefined, []),
+  ));
+
+  const value = {
+    variableApy: useVariableApy,
+    fixedApr: useFixedApr
+  };
+
+  return <AMMsCtx.Provider value={value}>{children}</AMMsCtx.Provider>;
+};
+
+export const useAMMsContext = (): AMMsContext => {
+  return useContext(AMMsCtx);
+};
+
+export default AMMsProvider;

--- a/src/contexts/AMMsContext/AMMsContext.tsx
+++ b/src/contexts/AMMsContext/AMMsContext.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo, useRef } from 'react';
-import { useAMM, useAsyncFunction, UseAsyncFunctionResult } from '@hooks';
+import { useAMM, useAsyncFunction, UseAsyncFunctionResult, useWallet } from '@hooks';
 import { AugmentedAMM } from '@utilities';
 import { createContext, useContext } from 'react'
 import { Position, PositionInfo } from '@voltz-protocol/v1-sdk/dist/types/entities';
+import { useGetWalletQuery, Wallet } from '@graphql';
 
 export type AMMsProviderProps = {
 };
@@ -10,8 +11,9 @@ export type AMMsProviderProps = {
 export type AMMsContext = {
     variableApy: (amm:AugmentedAMM) => UseAsyncFunctionResult<AugmentedAMM, number | void>;
     fixedApr: (amm:AugmentedAMM) => UseAsyncFunctionResult<AugmentedAMM, number | void>;
-    positionsInfo: Record<string,PositionInfo>;
+    positionsInfo: Record<string,PositionInfo|undefined>;
     cachePositionInfo: (info: PositionInfo, position: Position) => void;
+    isPositionFeched: (wallet: Wallet, previousWallet: Wallet, position?: Position) => boolean;
 }
 
 const AMMsCtx = createContext<AMMsContext>({} as unknown as AMMsContext);
@@ -22,11 +24,76 @@ export const AMMsProvider: React.FunctionComponent<AMMsProviderProps> = ({ child
   const variableApys = useRef<Record<string,number>>({});
   const fixedAprs = useRef<Record<string,number>>({});
 
-  const positionsInfo = useRef<Record<string,PositionInfo>>({});
+  const positionsInfo = useRef<Record<string,PositionInfo | undefined>>({});
 
   const cachePositionInfo = (info: PositionInfo, position: Position) => {
     positionsInfo.current[position.id] = info;
   }
+
+  const isPositionFeched = (wallet: Wallet, previousWallet: Wallet, position?: Position) => {
+    if (position) {
+      positionsInfo.current[position.id] = undefined;
+    }
+    if (!position) {
+      if ( wallet.positions && wallet.positions.length > previousWallet.positions.length) {
+        return true; 
+      }
+    } else {
+      let newPosition: Position | undefined = undefined;
+      if (position && wallet.positions) {
+        const poss = wallet.positions.filter((pos) => pos.id === position.id) as unknown as  Position[];
+        newPosition = poss[0];
+      }
+      if (position && wallet && newPosition){
+        if (newPosition.swaps.length > position.swaps.length ||
+          newPosition.burns.length > position.burns.length || 
+          newPosition.mints.length > position.mints.length ||
+          newPosition.marginUpdates.length > position.marginUpdates.length || 
+          newPosition.settlements.length > position.settlements.length) {
+            return true;
+        }
+      }
+    }
+    return false;
+
+  }
+
+  // const fetchSubgraphPosition = useAsyncFunction(
+  //   async (position?: Position) => {
+  //     if (position) {
+  //       positionsInfo.current[position.id] = undefined;
+  //     }
+  //     const { data, loading, error, stopPolling } = useGetWalletQuery({
+  //       variables: { id: wallet?.id || '' }
+  //     });
+  //     while (loading) {
+  //       const delay = new Promise(() => setTimeout(() => {}, 100));
+  //       await delay;
+  //     }
+  //     if (!position) {
+  //       if (data && data.wallet && wallet && data.wallet.positions.length > wallet.positions.length) {
+  //         return true; 
+  //       }
+  //     }else {
+  //       let newPosition: Position | undefined = undefined;
+  //       if (position && data && data.wallet && data.wallet.positions) {
+  //         const poss = data.wallet.positions.filter((pos) => pos.id === position.id) as unknown as  Position[];
+  //         newPosition = poss[0];
+  //       }
+  //       if (position && data && data.wallet && newPosition){
+  //         if (newPosition.swaps.length > position.swaps.length ||
+  //           newPosition.burns.length > position.burns.length || 
+  //           newPosition.mints.length > position.mints.length ||
+  //           newPosition.marginUpdates.length > position.marginUpdates.length || 
+  //           newPosition.settlements.length > position.settlements.length) {
+  //             return true;
+  //         }
+  //       }
+  //     }
+  //     return false;
+  //   },
+  //   useMemo(() => undefined, []),
+  // );
 
   const useVariableApy = (amm: AugmentedAMM) => (useAsyncFunction(
     async () => {
@@ -62,7 +129,8 @@ export const AMMsProvider: React.FunctionComponent<AMMsProviderProps> = ({ child
     variableApy: useVariableApy,
     fixedApr: useFixedApr,
     positionsInfo: positionsInfo.current,
-    cachePositionInfo
+    cachePositionInfo,
+    isPositionFeched
   };
 
   return <AMMsCtx.Provider value={value}>{children}</AMMsCtx.Provider>;

--- a/src/contexts/AMMsContext/AMMsContext.tsx
+++ b/src/contexts/AMMsContext/AMMsContext.tsx
@@ -34,6 +34,7 @@ export const AMMsProvider: React.FunctionComponent<AMMsProviderProps> = ({ child
     if (position) {
       positionsInfo.current[position.id] = undefined;
     }
+
     if (!position) {
       if ( wallet.positions && wallet.positions.length > previousWallet.positions.length) {
         return true; 
@@ -44,7 +45,7 @@ export const AMMsProvider: React.FunctionComponent<AMMsProviderProps> = ({ child
         const poss = wallet.positions.filter((pos) => pos.id === position.id) as unknown as  Position[];
         newPosition = poss[0];
       }
-      if (position && wallet && newPosition){
+      if (position && newPosition){
         if (newPosition.swaps.length > position.swaps.length ||
           newPosition.burns.length > position.burns.length || 
           newPosition.mints.length > position.mints.length ||
@@ -57,43 +58,6 @@ export const AMMsProvider: React.FunctionComponent<AMMsProviderProps> = ({ child
     return false;
 
   }
-
-  // const fetchSubgraphPosition = useAsyncFunction(
-  //   async (position?: Position) => {
-  //     if (position) {
-  //       positionsInfo.current[position.id] = undefined;
-  //     }
-  //     const { data, loading, error, stopPolling } = useGetWalletQuery({
-  //       variables: { id: wallet?.id || '' }
-  //     });
-  //     while (loading) {
-  //       const delay = new Promise(() => setTimeout(() => {}, 100));
-  //       await delay;
-  //     }
-  //     if (!position) {
-  //       if (data && data.wallet && wallet && data.wallet.positions.length > wallet.positions.length) {
-  //         return true; 
-  //       }
-  //     }else {
-  //       let newPosition: Position | undefined = undefined;
-  //       if (position && data && data.wallet && data.wallet.positions) {
-  //         const poss = data.wallet.positions.filter((pos) => pos.id === position.id) as unknown as  Position[];
-  //         newPosition = poss[0];
-  //       }
-  //       if (position && data && data.wallet && newPosition){
-  //         if (newPosition.swaps.length > position.swaps.length ||
-  //           newPosition.burns.length > position.burns.length || 
-  //           newPosition.mints.length > position.mints.length ||
-  //           newPosition.marginUpdates.length > position.marginUpdates.length || 
-  //           newPosition.settlements.length > position.settlements.length) {
-  //             return true;
-  //         }
-  //       }
-  //     }
-  //     return false;
-  //   },
-  //   useMemo(() => undefined, []),
-  // );
 
   const useVariableApy = (amm: AugmentedAMM) => (useAsyncFunction(
     async () => {

--- a/src/contexts/PortfolioContext/PortfolioContext.tsx
+++ b/src/contexts/PortfolioContext/PortfolioContext.tsx
@@ -2,6 +2,7 @@ import { useAgent, useAMM } from '@hooks';
 import { AugmentedAMM } from '@utilities';
 import { Position, PositionInfo } from '@voltz-protocol/v1-sdk/dist/types/entities';
 import { createContext, useContext, useEffect, useState, useRef } from 'react'
+import { useAMMsContext } from '../AMMsContext/AMMsContext';
 import { getHealthCounters, getNetPayingRate, getNetReceivingRate, getTotalAccruedCashflow, getTotalMargin, getTotalNotional } from './services';
 
 export type PortfolioProviderProps = {
@@ -36,6 +37,8 @@ export const PortfolioProvider: React.FunctionComponent<PortfolioProviderProps> 
 
   const { agent } = useAgent();
 
+  const {positionsInfo, cachePositionInfo} = useAMMsContext();
+
   useEffect(() => {
     if (positions) {
         for ( let  i = 0; i < positions.length; i++ ) {
@@ -57,13 +60,19 @@ export const PortfolioProvider: React.FunctionComponent<PortfolioProviderProps> 
 
   // 0x3044fa8f672424a31acf0069b9691e19a91a2711#0xf8f6b70a36f4398f0853a311dc6699aba8333cc1
   const loadPositionInfo = (position : Position) => {
-    position.amm.getPositionInformation(position).then( positionInfo => {
-      info.current[position.id] = positionInfo;
-      setLoaded(JSON.stringify(info.current));
-    }).catch( (e) => {
-      loadPositionInfo(position)
+    if (positionsInfo[position.id]) {
+      info.current[position.id] = positionsInfo[position.id];
+    } else {
+      position.amm.getPositionInformation(position).then( pInfo => {
+        info.current[position.id] = pInfo;
+        cachePositionInfo(pInfo, position);
+        setLoaded(JSON.stringify(info.current));
+      }).catch( (e) => {
+        loadPositionInfo(position)
+      }
+      );
     }
-    );
+    
   }
 
   const value = {

--- a/src/contexts/PortfolioContext/PortfolioContext.tsx
+++ b/src/contexts/PortfolioContext/PortfolioContext.tsx
@@ -1,6 +1,7 @@
 import { useAgent, useAMM } from '@hooks';
 import { AugmentedAMM } from '@utilities';
 import { Position, PositionInfo } from '@voltz-protocol/v1-sdk/dist/types/entities';
+import { isUndefined } from 'lodash';
 import { createContext, useContext, useEffect, useState, useRef } from 'react'
 import { useAMMsContext } from '../AMMsContext/AMMsContext';
 import { getHealthCounters, getNetPayingRate, getNetReceivingRate, getTotalAccruedCashflow, getTotalMargin, getTotalNotional } from './services';
@@ -60,8 +61,9 @@ export const PortfolioProvider: React.FunctionComponent<PortfolioProviderProps> 
 
   // 0x3044fa8f672424a31acf0069b9691e19a91a2711#0xf8f6b70a36f4398f0853a311dc6699aba8333cc1
   const loadPositionInfo = (position : Position) => {
-    if (positionsInfo[position.id]) {
-      info.current[position.id] = positionsInfo[position.id];
+    const posInfo = positionsInfo[position.id];
+    if (posInfo) {
+      info.current[position.id] = posInfo;
     } else {
       position.amm.getPositionInformation(position).then( pInfo => {
         info.current[position.id] = pInfo;

--- a/src/contexts/PortfolioContext/PortfolioContext.tsx
+++ b/src/contexts/PortfolioContext/PortfolioContext.tsx
@@ -41,6 +41,7 @@ export const PortfolioProvider: React.FunctionComponent<PortfolioProviderProps> 
   const {positionsInfo, cachePositionInfo} = useAMMsContext();
 
   useEffect(() => {
+    info.current={};
     if (positions) {
         for ( let  i = 0; i < positions.length; i++ ) {
             void loadPositionInfo(positions[i]);
@@ -49,7 +50,7 @@ export const PortfolioProvider: React.FunctionComponent<PortfolioProviderProps> 
   }, [positions]);
   
   useEffect(() => {
-    if (positions && positions.length > 0 && info.current && Object.keys(info.current).length === positions.length ) {
+    if (loaded.length > 0 && positions && positions.length > 0 && info.current && Object.keys(info.current).length === positions.length ) {
         setHealthCounters(getHealthCounters(positions, info.current));
         setTotalNotional(getTotalNotional(positions, info.current));
         setTotalMargin(getTotalMargin(positions, info.current));
@@ -64,6 +65,7 @@ export const PortfolioProvider: React.FunctionComponent<PortfolioProviderProps> 
     const posInfo = positionsInfo[position.id];
     if (posInfo) {
       info.current[position.id] = posInfo;
+      setLoaded(JSON.stringify(info.current));
     } else {
       position.amm.getPositionInformation(position).then( pInfo => {
         info.current[position.id] = pInfo;

--- a/src/contexts/WalletContext/ProviderWrapper.tsx
+++ b/src/contexts/WalletContext/ProviderWrapper.tsx
@@ -115,10 +115,14 @@ const ProviderWrapper: React.FunctionComponent<ProviderWrapperProps> = ({
   }, []);
 
   const pollInterval = polling ? 500 : undefined;
-  const { data, loading, error, stopPolling } = useGetWalletQuery({
+  const { data, loading, error, stopPolling, refetch } = useGetWalletQuery({
     variables: { id: account || '' },
     pollInterval,
+    fetchPolicy: 'no-cache',
+    nextFetchPolicy: 'no-cache'
   });
+
+  const doRefetch = useCallback(() => {refetch()}, [refetch]);
 
   const unresolvedTransactions = useSelector(selectors.unresolvedTransactionsSelector);
   const shouldPoll = unresolvedTransactions.length > 0;
@@ -146,6 +150,7 @@ const ProviderWrapper: React.FunctionComponent<ProviderWrapperProps> = ({
     required,
     setRequired,
     walletError,
+    refetch: doRefetch
   };
 
   return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>;

--- a/src/contexts/WalletContext/WalletContext.ts
+++ b/src/contexts/WalletContext/WalletContext.ts
@@ -19,7 +19,8 @@ const WalletContext = createContext<Wallet>({
   error: false,
   required: false,
   setRequired: (_required: boolean) => undefined,
-  walletError: null
+  walletError: null,
+  refetch: () => {}
 });
 
 export default WalletContext;

--- a/src/contexts/WalletContext/types.ts
+++ b/src/contexts/WalletContext/types.ts
@@ -34,6 +34,7 @@ export type Wallet = {
   setRequired: (required: boolean) => void;
   walletError: string | null;
   networkId?: string;
+  refetch: () => void;
 };
 
 export interface WalletRiskAssessment {

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -9,6 +9,7 @@ export * from './BorrowAMMContext/BorrowAMMContext';
 export * from './MintBurnFormContext/MintBurnFormContext';
 export * from './PositionContext/PositionContext';
 export * from './PortfolioContext/PortfolioContext';
+export * from './AMMsContext/AMMsContext';
 export * from './SwapFormContext/SwapFormContext';
 export { default as WalletProvider } from './WalletContext/WalletProvider';
 export { default as WalletContext } from './WalletContext/WalletContext';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,7 @@ import { ThemeProvider } from './theme';
 import { AgentProvider, WalletProvider } from './contexts';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import AMMsProvider from './contexts/AMMsContext/AMMsContext';
 
 // the root of the react app 
 
@@ -41,7 +42,9 @@ ReactDOM.render(
           <WalletProvider>
             <AgentProvider>
               <HashRouter>
-                <App />
+                <AMMsProvider>
+                  <App />
+                </AMMsProvider>
               </HashRouter>
             </AgentProvider>
           </WalletProvider>

--- a/src/routes/LiquidityProvider/LiquidityProvider.tsx
+++ b/src/routes/LiquidityProvider/LiquidityProvider.tsx
@@ -22,7 +22,7 @@ const LiquidityProvider: React.FunctionComponent = () => {
   const { amms } = useAMMs();
   const { onChangeAgent } = useAgent();
   const { pathname, key } = useLocation();
-  const { positions } = usePositions();
+  const { positions, positionsByAgent } = usePositions();
 
   const pathnameWithoutPrefix = pathname.slice(1);
   const renderMode = getRenderMode(formMode, pathnameWithoutPrefix);
@@ -93,7 +93,7 @@ const LiquidityProvider: React.FunctionComponent = () => {
       )}
 
       {renderMode === 'portfolio' && (
-        <PortfolioProvider positions={positions}>
+        <PortfolioProvider positions={positionsByAgent}>
           <ConnectedPositionTable 
           amm={amm}
           onSelectItem={handleSelectPosition}


### PR DESCRIPTION
Main improvements:
- best practices: fetch data in parent component and pass it down to children
- remove blur background and replace it with opaque svg
- Positions and AMMs data caching: data loads as normal (slow) when you first enter a certain page but loading is much faster when navigating back
- Waiting for subgraph to update after transaction: pending transaction screen keeps showing _loading_ until the subgraph is updated. When going back to portfolio, there's no need to reload the page, the data is already fetched
- -- subgraph fetching on Goerli proved to be relatively quick (~1sec)