### PR TITLE
feat: user sees max withdrawable margin

### DIFF
--- a/src/components/composite/MarginAmount/MarginAmount.tsx
+++ b/src/components/composite/MarginAmount/MarginAmount.tsx
@@ -43,14 +43,9 @@ const MarginAmount: React.FunctionComponent<MarginAmountProps> = ({
   const swapForm = useSwapFormContext();
   const positionForm = usePositionContext();
 
-  let marginAmount;
-  if (underlyingTokenName?.includes('USD')) {
-    const portfolioMarginInfo = positionForm.position?.margin.toString();
-    marginAmount = !isUndefined(portfolioMarginInfo) ? parseInt(portfolioMarginInfo)/1e6 : defaultMargin;
-  } else {
-    const portfolioMarginInfo = positionForm.position?.margin.toString();
-    marginAmount = !isUndefined(portfolioMarginInfo) ? parseInt(portfolioMarginInfo) / 1e18 : defaultMargin;
-  }
+  const divisor = underlyingTokenName?.includes('USD') ? 1e6 : 1e18;
+  const portfolioMarginInfo = positionForm.position?.margin.toString();
+  const marginAmount = !isUndefined(portfolioMarginInfo) ? parseInt(portfolioMarginInfo) / divisor : defaultMargin;
   const initialMarginRequirement = swapForm?.minRequiredMargin || defaultMargin;
 
   const maxAmountToWithdraw = !isUndefined(marginAmount) && !isUndefined(initialMarginRequirement) ? (marginAmount - initialMarginRequirement) : undefined;


### PR DESCRIPTION
- User should see how much they can actually withdraw from their margin position when trying to unwind a position or cash out.
- WIP as the data retrieval for the margin amount should ideally happen from the PortfolioContext but it is returning undefined for the margin information @ssbarbee let us review this together. 
