### PR TITLE
fix: prevent risky wallet error msg being overridden

### DIFF
--- a/src/contexts/WalletContext/ProviderWrapper.tsx
+++ b/src/contexts/WalletContext/ProviderWrapper.tsx
@@ -98,6 +98,8 @@ const ProviderWrapper: React.FunctionComponent<ProviderWrapperProps> = ({
         let errorMessage = getErrorMessage(error).trim();
         if (errorMessage.includes('Wrong network')) {
           errorMessage = 'Wrong network';
+        } else if (errorMessage.includes('Risky Account Detected')) {
+          errorMessage = 'Risky Account Detected';
         } else {
           errorMessage = 'Failed connection';
         }


### PR DESCRIPTION
- Prevent risky wallet error message being overridden by the general error msg in ProviderWrapper