### PR TITLE
fix: card background & hide withdraw and lp opt tag

### DIFF
--- a/src/components/interface/EcosystemHeader/EcosystemHeader.tsx
+++ b/src/components/interface/EcosystemHeader/EcosystemHeader.tsx
@@ -29,7 +29,8 @@ const EcosystemHeader = ({
           </Typography>
         </Box>
         <Box sx={{ marginTop: '16px', display: 'flex' }}>
-          <Box sx={{ ...boxStyles, border: '1px solid #FF4AA9' }}>
+          {/* TODO: add back LP OPTIMISER tag when count > 1  */}
+          {/* <Box sx={{ ...boxStyles, border: '1px solid #FF4AA9' }}>
             <Typography variant="h6" sx={{ ...tagStyles, color: '#FF4AA9' }}>
               {lpOptimizerTag}
               {lpOptimizerCount > 0 ? ':' : ''}
@@ -37,7 +38,7 @@ const EcosystemHeader = ({
             <Typography variant="h6" sx={{ ...tagStyles, color: '#E5E1F9', paddingLeft: '8px' }}>
               {lpOptimizerCount ? lpOptimizerCount : 's00n'}
             </Typography>
-          </Box>
+          </Box> */}
 
           <Box sx={{ ...boxStyles, border: '1px solid #2667FF', marginLeft: '8px' }}>
             <Typography variant="h6" sx={{ ...tagStyles, color: '#2667FF' }}>

--- a/src/components/interface/MellowLPTable/components/MellowLPEntry.tsx
+++ b/src/components/interface/MellowLPTable/components/MellowLPEntry.tsx
@@ -22,8 +22,10 @@ const MellowLPEntry: React.FunctionComponent<MellowLPEntryProps> = ({
   return (
     <Box
       sx={{
+        backgroundColor: '#19152A',
+        padding: '16px',
         maxWidth: '308px',
-        maxHeight: '340px',
+        maxHeight: '408px',
         width: '100%',
         height: '100%',
         filter: 'drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25))',

--- a/src/components/interface/MellowLpDepositForm/components/LPMellowVaultDepositWindow.tsx
+++ b/src/components/interface/MellowLpDepositForm/components/LPMellowVaultDepositWindow.tsx
@@ -58,7 +58,8 @@ const LPMellowVaultDepositWindow: React.FunctionComponent<LPMellowVaultDepositWi
           </Typography>
         </Box>
 
-        <Box sx={{ borderBottom: '1px solid #2A2444', marginLeft: '16px' }}>
+        {/* TODO enable WITHDRAW once feature is supported (maturity) */}
+        {/* <Box sx={{ borderBottom: '1px solid #2A2444', marginLeft: '16px' }}>
           <Typography
             variant="h1"
             sx={{
@@ -71,7 +72,7 @@ const LPMellowVaultDepositWindow: React.FunctionComponent<LPMellowVaultDepositWi
           >
             WITHDRAW
           </Typography>
-        </Box>
+        </Box> */}
       </Box>
 
       <Typography


### PR DESCRIPTION
Issues fixed 
- hide withdraw since it’s not supported until the maturity of the pool/vault 
- remove “LP Optimisor: 1” in the ecosystem page, keep “Alpha Pools: soon”, etc 
- main card is missing background 