### PR TITLE
fix: remove not needed renders for the static component Nav

### DIFF
--- a/src/components/interface/Nav/Nav.tsx
+++ b/src/components/interface/Nav/Nav.tsx
@@ -6,7 +6,7 @@ import { NavLink } from './NavLink/NavLink';
 import { iconSx } from './NavLink/style';
 import { colors } from '@theme';
 
-const Nav: React.FunctionComponent = () => (
+const Nav: React.FunctionComponent = React.memo(() => (
   <Box
     sx={{
       display: 'flex',
@@ -74,32 +74,31 @@ const Nav: React.FunctionComponent = () => (
       </NavLink>
     )}
 
-    
-      <NavLink
-        isNew={true}
-        subLinks={
-          process.env.REACT_APP_ECOSYSTEM && process.env.REACT_APP_ECOSYSTEM !== `UNPROVIDED` ?
-          [
-            {
-              text: 'PRODUCTS',
-              link: `/${routes.PRODUCTS}`,
-            },
-            {
-              text: 'FIXED BORROW',
-              link: `/${routes.BORROW_POS}`,
-            },
-          ] : [
-            {
-              text: 'FIXED BORROW',
-              link: `/${routes.BORROW_POS}`,
-            },
-          ]
-        }
-        
-      >
-        Ecosystem
-      </NavLink>
+    <NavLink
+      isNew={true}
+      subLinks={
+        process.env.REACT_APP_ECOSYSTEM && process.env.REACT_APP_ECOSYSTEM !== `UNPROVIDED`
+          ? [
+              {
+                text: 'PRODUCTS',
+                link: `/${routes.PRODUCTS}`,
+              },
+              {
+                text: 'FIXED BORROW',
+                link: `/${routes.BORROW_POS}`,
+              },
+            ]
+          : [
+              {
+                text: 'FIXED BORROW',
+                link: `/${routes.BORROW_POS}`,
+              },
+            ]
+      }
+    >
+      Ecosystem
+    </NavLink>
   </Box>
-);
+));
 
 export default Nav;


### PR DESCRIPTION
Using React.memo makes sense for this component since it is just static one. Look the before and after videos

https://user-images.githubusercontent.com/11079632/199205970-c58d7a04-8d1c-4dc7-a20a-e07069807939.mov


https://user-images.githubusercontent.com/11079632/199205950-1a045da8-771d-4921-bd23-d018bdb6103a.mov

