### PR TITLE
feat: add typescript check as validation on pipeline

### DIFF
--- a/.github/workflows/pull-request-staging-main.yaml
+++ b/.github/workflows/pull-request-staging-main.yaml
@@ -20,9 +20,11 @@ jobs:
           node-version: 'lts/*'
       - name: Install dependencies
         run: make install-ci
-      - name: Run eslint check
+      - name: Eslint check
         run: make eslint-check
-      - name: Run prettier check
+      - name: Prettier check
         run: make prettier-check
+      - name: Typescript check
+        run: make ts-check
       - name: Run tests
         run: make test 

--- a/.github/workflows/push-main.yaml
+++ b/.github/workflows/push-main.yaml
@@ -19,10 +19,12 @@ jobs:
           node-version: 'lts/*'
       - name: Install dependencies
         run: make install-ci
-      - name: Run eslint check
+      - name: Eslint check
         run: make eslint-check
-      - name: Run prettier check
+      - name: Prettier check
         run: make prettier-check
+      - name: Typescript check
+        run: make ts-check
       - name: Run tests
         run: make test
       - name: Release

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ install-ci:
 test:
 	yarn test
 
+ts-check:
+	yarn ts:check
+
 eslint-check:
 	yarn lint:check
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "node scripts/build.js",
     "build-storybook": "build-storybook",
     "generate": "graphql-codegen --config graphql-codegen.yaml",
+    "ts:check": "tsc --noEmit",
     "lint:check": "eslint 'src/**/*.{ts,tsx}'",
     "lint:fix": "eslint --fix 'src/**/*.{ts,tsx}'",
     "prettier:check": "prettier --check './src/**/*.{ts,tsx}' './scripts/**/*.js' './.storybook/**/*.js'",

--- a/src/utilities/getENSDetails.ts
+++ b/src/utilities/getENSDetails.ts
@@ -1,5 +1,4 @@
 import { ethers } from 'ethers';
-import { ExternalProvider } from '@ethersproject/providers/src.ts/web3-provider';
 
 type ENSDetails = {
   name: string;
@@ -20,7 +19,7 @@ export const getENSDetails = async (address?: string | null): Promise<ENSDetails
   if (CACHED_ENS[address] !== undefined) {
     return CACHED_ENS[address];
   }
-  const provider = new ethers.providers.Web3Provider(window.ethereum as ExternalProvider);
+  const provider = new ethers.providers.Web3Provider(window.ethereum as never);
   const name = await provider.lookupAddress(address);
   if (!name) {
     CACHED_ENS[address] = null;


### PR DESCRIPTION
Running tsc --noEmit on pipeline checks the types of the entire project. We often run into problems because we don't have this check.