### PR TITLE
Fix allowance handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/react": "7.25.0",
     "@sentry/tracing": "7.25.0",
-    "@voltz-protocol/v1-sdk": "1.23.1",
+    "@voltz-protocol/v1-sdk": "1.24.3",
     "@walletconnect/ethereum-provider": "1.8.0",
     "@walletconnect/web3-provider": "1.8.0",
     "aws-amplify": "4.3.44",

--- a/src/contexts/SwapFormContext/SwapFormContext.tsx
+++ b/src/contexts/SwapFormContext/SwapFormContext.tsx
@@ -110,7 +110,7 @@ export const SwapFormProvider: React.FunctionComponent<SwapFormProviderProps> = 
   const { swapInfo, expectedApyInfo } = useAMMContext();
   const cachedSwapInfoMinRequiredMargin = useRef<number>();
   const [cachedSwapInfoAvailableNotional, setCachedSwapInfoAvailableNotional] = useState<number>();
-  const tokenApprovals = useTokenApproval(poolAmm);
+  const tokenApprovals = useTokenApproval(poolAmm, margin);
   const [userSimulatedVariableApy, setUserSimulatedVariableApy] = useState<number | undefined>(
     undefined,
   );

--- a/src/contexts/WalletContext/services.ts
+++ b/src/contexts/WalletContext/services.ts
@@ -26,7 +26,10 @@ const unavailableText = 'Service unavailable, please try again shortly';
 export const checkForCorrectNetwork = async (provider: ethers.providers.JsonRpcProvider) => {
   try {
     const network = await provider.getNetwork();
-    if (network.name !== process.env.REACT_APP_REQUIRED_ETHEREUM_NETWORK) {
+    if (
+      !!process.env.REACT_APP_REQUIRED_ETHEREUM_NETWORK &&
+      network.name !== process.env.REACT_APP_REQUIRED_ETHEREUM_NETWORK
+    ) {
       throw new Error(
         `Connected to '${network.name}' instead of '${
           process.env.REACT_APP_REQUIRED_ETHEREUM_NETWORK || '<unknown>'

--- a/src/hooks/useTokenApproval.ts
+++ b/src/hooks/useTokenApproval.ts
@@ -18,7 +18,7 @@ export type ApprovalErrorResponse = {
   message: string;
 };
 
-export const useTokenApproval = (amm: AMM) => {
+export const useTokenApproval = (amm: AMM, margin?: number) => {
   const [checkingApprovals, setCheckingApprovals] = useState(false);
   const [approving, setApproving] = useState(false);
   const [lastApproval, setLastApproval] = useState<ApprovalInfo>();
@@ -41,7 +41,7 @@ export const useTokenApproval = (amm: AMM) => {
     setLastError(undefined);
 
     amm
-      .isUnderlyingTokenApprovedForPeriphery()
+      .isTokenApprovedForPeriphery(amm.underlyingToken.id, margin)
       .then((response) => {
         setUnderlyingTokenApprovedForPeriphery(response ?? false);
       })
@@ -51,7 +51,7 @@ export const useTokenApproval = (amm: AMM) => {
       .finally(() => {
         setCheckingApprovals(false);
       });
-  }, [amm, setUnderlyingTokenApprovedForPeriphery]);
+  }, [amm, margin, setUnderlyingTokenApprovedForPeriphery]);
 
   const approveUnderlyingTokenForPeriphery = useCallback(async () => {
     setApproving(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7647,10 +7647,10 @@
     "@typescript-eslint/types" "5.9.1"
     eslint-visitor-keys "^3.0.0"
 
-"@voltz-protocol/v1-sdk@1.23.1":
-  version "1.23.1"
-  resolved "https://registry.yarnpkg.com/@voltz-protocol/v1-sdk/-/v1-sdk-1.23.1.tgz#ca3b11107178f11cefac4fd039032a73e69835ee"
-  integrity sha512-K5viR18ZayM64Y1+OkpsKEdfhk7SUjedYbZjYI6uqt/nRfNNYNnlevC6mJwAgbcV1Fn/ZzQ0evCVR7odDtXgSQ==
+"@voltz-protocol/v1-sdk@1.24.3":
+  version "1.24.3"
+  resolved "https://registry.yarnpkg.com/@voltz-protocol/v1-sdk/-/v1-sdk-1.24.3.tgz#c40f8064e1bbce3818a5860dbb3b069c33c2c8cb"
+  integrity sha512-kt9QOQHpRBmBuAtJVPu7fr0DW4a42dcWN7eRN0UPQVCkwsyaPAvAwE5DI+VyARMO8edaNbb2nSC8d7slyHEB5A==
   dependencies:
     "@apollo/client" "^3.7.1"
     "@ethersproject/address" "^5.7.0"


### PR DESCRIPTION
## Description

fix token approvals issues, making use of API 2.0.0
 - dispaly helpful error if approval is goign to fail, warning about tokens like USDT that don't allow approvals on top on non-zero allowances
 - don't require approval if the margin being supplied is less than the existing allowance

## Amplify hosted environment link

Not possible till SDK PR merged and SDK major version is incremented: https://github.com/Voltz-Protocol/v1-sdk/pull/138

## Notion link

https://www.notion.so/voltz/USDT-LP-Approval-bug-73fc8dedf83c4b00baa3c55965edaf28