### PR TITLE
Mellow withdrawal testnet qa fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/react": "7.25.0",
     "@sentry/tracing": "7.25.0",
-    "@voltz-protocol/v1-sdk": "1.17.0",
+    "@voltz-protocol/v1-sdk": "file:.yalc/@voltz-protocol/v1-sdk",
     "@walletconnect/ethereum-provider": "1.8.0",
     "@walletconnect/web3-provider": "1.8.0",
     "aws-amplify": "4.3.44",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/react": "7.25.0",
     "@sentry/tracing": "7.25.0",
-    "@voltz-protocol/v1-sdk": "file:.yalc/@voltz-protocol/v1-sdk",
+    "@voltz-protocol/v1-sdk": "1.20.0",
     "@walletconnect/ethereum-provider": "1.8.0",
     "@walletconnect/web3-provider": "1.8.0",
     "aws-amplify": "4.3.44",

--- a/src/routes/LPOptimisers/VaultFormRoute/Form/DepositAmountInput/DepositAmountInput.tsx
+++ b/src/routes/LPOptimisers/VaultFormRoute/Form/DepositAmountInput/DepositAmountInput.tsx
@@ -7,7 +7,7 @@ import { toUSFormat } from '../../../../../utilities/number';
 import { MaskedIntegerFieldStyled } from './DepositAmountInput.styled';
 
 type Props = {
-  subtext: string;
+  subtext?: string;
   token: string;
   value: number;
   disabled: boolean;

--- a/src/routes/LPOptimisers/VaultFormRoute/Form/MaturityDistribution/MaturityDistribution.styled.tsx
+++ b/src/routes/LPOptimisers/VaultFormRoute/Form/MaturityDistribution/MaturityDistribution.styled.tsx
@@ -16,6 +16,7 @@ export const ToggleBox = styled(Box)`
   justify-content: space-between;
   width: 100%;
   box-sizing: border-box;
+  margin-bottom: ${({ theme }) => theme.spacing(4)};
 `;
 
 export const MaturityDistributionErrorTypography = styled(Typography)`

--- a/src/routes/LPOptimisers/VaultFormRoute/Form/MaturityDistribution/MaturityDistribution.tsx
+++ b/src/routes/LPOptimisers/VaultFormRoute/Form/MaturityDistribution/MaturityDistribution.tsx
@@ -52,7 +52,7 @@ export const MaturityDistribution: React.FunctionComponent<MaturityDistributionP
   return (
     <MaturityDistributionBox>
       <ToggleBox>
-        {weights.length > 1 && (
+        {weights.filter(w => w.distribution > 0).length > 1 && (
           <MaturityDistributionToggle
             disabled={disabledToggle}
             distribution={distribution}
@@ -70,25 +70,32 @@ export const MaturityDistribution: React.FunctionComponent<MaturityDistributionP
       </ToggleBox>
       <MaturityDistributionHeader />
       <MaturityDistributionsBox>
-        {weights.map((weight, index) => (
-          <MaturityDistributionEntry
-            key={`${index}-${distribution}`}
-            disabled={distribution === 'automatic' || weights[index].vaultDisabled}
-            onChange={(newDistribution) => {
-              if (distribution === 'automatic') {
-                return;
-              }
-              const weightCopies = weights.map((m) => ({ ...m }));
-              weightCopies[index].distribution = newDistribution;
-              onManualDistributionsUpdate(weightCopies);
-            }}
-            {...weight}
-          />
-        ))}
+        {weights.map((weight, index) => {
+          if (weight.distribution === 0) {
+            return null;
+          }
+
+          return (
+            <MaturityDistributionEntry
+              key={`${index}-${distribution}`}
+              disabled={distribution === 'automatic' || weights[index].vaultDisabled}
+              onChange={(newDistribution) => {
+                if (distribution === 'automatic') {
+                  return;
+                }
+                const weightCopies = weights.map((m) => ({ ...m }));
+                weightCopies[index].distribution = newDistribution;
+                onManualDistributionsUpdate(weightCopies);
+              }}
+              {...weight}
+            />
+          )
+        }
+        )}
       </MaturityDistributionsBox>
       {distribution === 'manual' &&
-      !allVaultsWeightEditingDisabled &&
-      combinedWeightValue !== 100 ? (
+        !allVaultsWeightEditingDisabled &&
+        combinedWeightValue !== 100 ? (
         <MaturityDistributionErrorTypography>
           The total distribution is {combinedWeightValue}%, it has to be 100%.
         </MaturityDistributionErrorTypography>

--- a/src/routes/LPOptimisers/VaultFormRoute/Form/MaturityDistribution/MaturityDistribution.tsx
+++ b/src/routes/LPOptimisers/VaultFormRoute/Form/MaturityDistribution/MaturityDistribution.tsx
@@ -52,7 +52,7 @@ export const MaturityDistribution: React.FunctionComponent<MaturityDistributionP
   return (
     <MaturityDistributionBox>
       <ToggleBox>
-        {weights.filter(w => w.distribution > 0).length > 1 && (
+        {weights.filter((w) => w.distribution > 0).length > 1 && (
           <MaturityDistributionToggle
             disabled={disabledToggle}
             distribution={distribution}
@@ -89,13 +89,12 @@ export const MaturityDistribution: React.FunctionComponent<MaturityDistributionP
               }}
               {...weight}
             />
-          )
-        }
-        )}
+          );
+        })}
       </MaturityDistributionsBox>
       {distribution === 'manual' &&
-        !allVaultsWeightEditingDisabled &&
-        combinedWeightValue !== 100 ? (
+      !allVaultsWeightEditingDisabled &&
+      combinedWeightValue !== 100 ? (
         <MaturityDistributionErrorTypography>
           The total distribution is {combinedWeightValue}%, it has to be 100%.
         </MaturityDistributionErrorTypography>

--- a/src/routes/LPOptimisers/VaultFormRoute/Form/MaturityDistribution/MaturityDistribution.tsx
+++ b/src/routes/LPOptimisers/VaultFormRoute/Form/MaturityDistribution/MaturityDistribution.tsx
@@ -72,6 +72,7 @@ export const MaturityDistribution: React.FunctionComponent<MaturityDistributionP
       <MaturityDistributionsBox>
         {weights.map((weight, index) => {
           if (weight.distribution === 0) {
+            // can't replace this with filter because it screws up index
             return null;
           }
 

--- a/src/routes/LPOptimisers/VaultFormRoute/Form/MaturityDistribution/MaturityDistributionToggle/MaturityDistributionToggle.styled.tsx
+++ b/src/routes/LPOptimisers/VaultFormRoute/Form/MaturityDistribution/MaturityDistributionToggle/MaturityDistributionToggle.styled.tsx
@@ -19,7 +19,6 @@ export const MaturityDistributionBox = styled(Box)`
   display: flex;
   flex-direction: column;
   row-gap: ${({ theme }) => theme.spacing(2)};
-  margin-bottom: ${({ theme }) => theme.spacing(4)};
 `;
 
 export const ToggleButton = styled(ToggleButtonComponent)`

--- a/src/routes/LPOptimisers/VaultFormRoute/Form/WithdrawRolloverForm/WithdrawRolloverForm.tsx
+++ b/src/routes/LPOptimisers/VaultFormRoute/Form/WithdrawRolloverForm/WithdrawRolloverForm.tsx
@@ -71,11 +71,7 @@ export const WithdrawRolloverForm: React.FunctionComponent<WithdrawRolloverFormP
         onDistributionToggle={onDistributionToggle}
         onManualDistributionsUpdate={onManualDistributionsUpdate}
       />
-      <DepositAmountInput
-        disabled={true}
-        token={lpVault.metadata.token}
-        value={depositValue}
-      />
+      <DepositAmountInput disabled={true} token={lpVault.metadata.token} value={depositValue} />
       <FullButtonBox>
         <ButtonBox>
           <FormActionButton

--- a/src/routes/LPOptimisers/VaultFormRoute/Form/WithdrawRolloverForm/WithdrawRolloverForm.tsx
+++ b/src/routes/LPOptimisers/VaultFormRoute/Form/WithdrawRolloverForm/WithdrawRolloverForm.tsx
@@ -1,8 +1,6 @@
 import { MellowProduct } from '@voltz-protocol/v1-sdk';
-import isUndefined from 'lodash.isundefined';
 import React from 'react';
 
-import { formatCurrency } from '../../../../../utilities/number';
 import { AboutYourFunds } from '../AboutYourFunds/AboutYourFunds';
 import { BackButton, ButtonBox, FormBox, FullButtonBox } from '../CommonForm.styled';
 import { DepositAmountInput } from '../DepositAmountInput/DepositAmountInput';
@@ -61,11 +59,6 @@ export const WithdrawRolloverForm: React.FunctionComponent<WithdrawRolloverFormP
   onManualDistributionsUpdate,
   combinedWeightValue,
 }: WithdrawRolloverFormProps) => {
-  const subtext = `WALLET BALANCE: ${
-    isUndefined(lpVault.userWalletBalance)
-      ? '---'
-      : `${formatCurrency(lpVault.userWalletBalance, true)} ${lpVault.metadata.token}`
-  }`;
   const loading = rolloverLoading || withdrawLoading;
   return (
     <FormBox>
@@ -80,7 +73,6 @@ export const WithdrawRolloverForm: React.FunctionComponent<WithdrawRolloverFormP
       />
       <DepositAmountInput
         disabled={true}
-        subtext={subtext}
         token={lpVault.metadata.token}
         value={depositValue}
       />

--- a/src/routes/LPOptimisers/VaultFormRoute/VaultWithdrawRolloverForm/VaultWithdrawRolloverForm.tsx
+++ b/src/routes/LPOptimisers/VaultFormRoute/VaultWithdrawRolloverForm/VaultWithdrawRolloverForm.tsx
@@ -98,12 +98,12 @@ export const VaultWithdrawRolloverForm: React.FunctionComponent<VaultWithdrawRol
       }
       rolloverLoading={submissionState.rollover.loading}
       rolloverSubmitText={submissionState.rollover.submitText}
-      rolloverSuccess={submissionState.withdraw.success}
+      rolloverSuccess={submissionState.rollover.success}
       weights={weights}
       withdrawDisabled={submissionState.disabled || loading || !vault.withdrawable(vaultIndex)}
       withdrawLoading={submissionState.withdraw.loading}
       withdrawSubmitText={submissionState.withdraw.submitText}
-      withdrawSuccess={submissionState.rollover.success}
+      withdrawSuccess={submissionState.withdraw.success}
       onDistributionToggle={setDistribution}
       onGoBack={onGoBack}
       onManualDistributionsUpdate={setManualWeights}

--- a/src/routes/LPOptimisers/VaultFormRoute/VaultWithdrawRolloverForm/mappers.ts
+++ b/src/routes/LPOptimisers/VaultFormRoute/VaultWithdrawRolloverForm/mappers.ts
@@ -142,7 +142,7 @@ export const getSubmissionState = ({
     case WithdrawStates.WITHDRAW_DONE: {
       return {
         hintText: {
-          text: 'Withdrawn successful',
+          text: 'Withdrawn successfully',
           textColor: colors.skyBlueCrayola.base,
         },
         disabled: true,
@@ -185,7 +185,7 @@ export const getSubmissionState = ({
     case RolloverStates.ROLLOVER_DONE: {
       return {
         hintText: {
-          text: 'Rollover successful',
+          text: 'Rolled over successfully',
           textColor: colors.skyBlueCrayola.base,
         },
         disabled: true,

--- a/src/routes/LPPortfolio/Optimisers/Optimisers.tsx
+++ b/src/routes/LPPortfolio/Optimisers/Optimisers.tsx
@@ -72,7 +72,7 @@ export const Optimisers: React.FunctionComponent = () => {
             maturityTimestampMS: vVaults.maturityTimestampMS,
             isCompleted: vault.withdrawable(vaultIndex),
             poolsCount: vVaults.pools.length,
-            currentBalance: vault.userIndividualCommittedDeposits[vaultIndex],
+            currentBalance: vault.userIndividualDeposits[vaultIndex],
             distribution: vVaults.weight,
           }))}
           onChangeAutomaticRolloverStatePromise={automaticRolloverChangePromise}

--- a/src/routes/LPPortfolio/Optimisers/VaultListItem/VaultListItem.tsx
+++ b/src/routes/LPPortfolio/Optimisers/VaultListItem/VaultListItem.tsx
@@ -112,39 +112,46 @@ export const VaultListItem: React.FunctionComponent<VaultListItemProps> = ({
           (
             { poolsCount, currentBalance, distribution, isCompleted, maturityTimestampMS },
             vaultIndex,
-          ) => (
-            <VaultListItemInfo key={maturityTimestampMS}>
-              <MaturityInfoBox>
-                <MaturityDateTypography>
-                  {formatPOSIXTimestamp(maturityTimestampMS)}
-                  {isCompleted ? ' -' : ''}
-                </MaturityDateTypography>
+          ) => {
+            if (currentBalance <= 0) {
+              // can't replace this with filter because it screws up vaultIndex
+              return null;
+            }
+
+            return (
+              <VaultListItemInfo key={maturityTimestampMS}>
+                <MaturityInfoBox>
+                  <MaturityDateTypography>
+                    {formatPOSIXTimestamp(maturityTimestampMS)}
+                    {isCompleted ? ' -' : ''}
+                  </MaturityDateTypography>
+                  {isCompleted ? (
+                    <MaturityCompleteTypography>&nbsp;Completed</MaturityCompleteTypography>
+                  ) : null}
+                </MaturityInfoBox>
+                <DistributionBox>
+                  {distribution}
+                  <TokenTypography>%</TokenTypography>
+                </DistributionBox>
+                <CurrentBalanceBox>
+                  {compactFormat(currentBalance)}
+                  <TokenTypography>{token.toUpperCase()}</TokenTypography>
+                </CurrentBalanceBox>
+                <PoolsCountBox>{poolsCount}</PoolsCountBox>
                 {isCompleted ? (
-                  <MaturityCompleteTypography>&nbsp;Completed</MaturityCompleteTypography>
+                  <ManageButton
+                    to={`/${generatePath(routes.LP_OPTIMISERS_WITHDRAW_ROLLOVER_FORM, {
+                      actions: 'manage',
+                      vaultId: id,
+                      vaultIndex: vaultIndex.toString(),
+                    })}`}
+                  >
+                    Manage
+                  </ManageButton>
                 ) : null}
-              </MaturityInfoBox>
-              <DistributionBox>
-                {distribution}
-                <TokenTypography>%</TokenTypography>
-              </DistributionBox>
-              <CurrentBalanceBox>
-                {compactFormat(currentBalance)}
-                <TokenTypography>{token.toUpperCase()}</TokenTypography>
-              </CurrentBalanceBox>
-              <PoolsCountBox>{poolsCount}</PoolsCountBox>
-              {isCompleted && currentBalance > 0 ? (
-                <ManageButton
-                  to={`/${generatePath(routes.LP_OPTIMISERS_WITHDRAW_ROLLOVER_FORM, {
-                    actions: 'manage',
-                    vaultId: id,
-                    vaultIndex: vaultIndex.toString(),
-                  })}`}
-                >
-                  Manage
-                </ManageButton>
-              ) : null}
-            </VaultListItemInfo>
-          ),
+              </VaultListItemInfo>
+            )
+          },
         )}
       </VaultListItemBottomBox>
     </VaultListItemBox>

--- a/src/routes/LPPortfolio/Optimisers/VaultListItem/VaultListItem.tsx
+++ b/src/routes/LPPortfolio/Optimisers/VaultListItem/VaultListItem.tsx
@@ -150,7 +150,7 @@ export const VaultListItem: React.FunctionComponent<VaultListItemProps> = ({
                   </ManageButton>
                 ) : null}
               </VaultListItemInfo>
-            )
+            );
           },
         )}
       </VaultListItemBottomBox>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7647,8 +7647,10 @@
     "@typescript-eslint/types" "5.9.1"
     eslint-visitor-keys "^3.0.0"
 
-"@voltz-protocol/v1-sdk@file:.yalc/@voltz-protocol/v1-sdk":
-  version "1.19.0"
+"@voltz-protocol/v1-sdk@1.20.0":
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/@voltz-protocol/v1-sdk/-/v1-sdk-1.20.0.tgz#ea4615675601aa095a275befdead7e81224289c5"
+  integrity sha512-kFQbI4QMYgOSVL9eGGuMtiLYiaJJUne4+/OH+JqQqUVn2+RL0nfonfkX0nF6ja9CZFynOYTf4QQ24o8byOpSNA==
   dependencies:
     "@apollo/client" "^3.7.1"
     "@ethersproject/address" "^5.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7647,10 +7647,8 @@
     "@typescript-eslint/types" "5.9.1"
     eslint-visitor-keys "^3.0.0"
 
-"@voltz-protocol/v1-sdk@1.17.0":
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/@voltz-protocol/v1-sdk/-/v1-sdk-1.17.0.tgz#ea666da3589eafd77d13596ba3bb562ded24786d"
-  integrity sha512-Qrsou5EfyiBwbSoWsxE0US9wM+hStyZQJUM3SpRxeyQ/6FfbcxIUPknnT4mppVuuFHetSuFa4HSxAbPvYCAvgA==
+"@voltz-protocol/v1-sdk@file:.yalc/@voltz-protocol/v1-sdk":
+  version "1.19.0"
   dependencies:
     "@apollo/client" "^3.7.1"
     "@ethersproject/address" "^5.7.0"


### PR DESCRIPTION
# Title

Mellow withdrawal testnet qa fixes

## Description

- Tick is on Withdraw ALL rather than Rollover ALL (it seems that ✅ is on the other button all the time)
- If you don’t have any funds into one maturity, hide it
- Remove wallet balance from the withdraw/rollover form
- typo “withdrawn successfully”
- pending deposit total vs individual
- if matured, then don’t show in the underlying pools
- make underlying pools unique
- if matured, then don’t show in the distribution

## Amplify hosted environment link

https://feat-mellow-withdrawal-testnet-qa-fixes.d2f2fhja7tsifl.amplifyapp.com/

## Notion link

https://www.notion.so/voltz/Testnet-QA-fixes-Mellow-Withdrawals-and-Rollovers-69398367673545aa8f27a4912728fe83

## Screenshots/videos section

If applicable...
