### PR TITLE
Release/20230103 post s1 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voltz-ui",
-  "version": "1.52.2",
+  "version": "1.52.3",
   "description": "A UI client for the Voltz Protocol",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/react": "7.25.0",
     "@sentry/tracing": "7.25.0",
-    "@voltz-protocol/v1-sdk": "1.30.0",
+    "@voltz-protocol/v1-sdk": "1.30.1",
     "@walletconnect/ethereum-provider": "1.8.0",
     "@walletconnect/web3-provider": "1.8.0",
     "aws-amplify": "4.3.44",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7647,10 +7647,10 @@
     "@typescript-eslint/types" "5.9.1"
     eslint-visitor-keys "^3.0.0"
 
-"@voltz-protocol/v1-sdk@1.30.0":
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/@voltz-protocol/v1-sdk/-/v1-sdk-1.30.0.tgz#a67150f4af839d29b1702fd00e01122cc3e52251"
-  integrity sha512-VgiJirA28M14bGhPG/jusumBhwx8FbuKWJ1SmgZ+o/x02XN97QkfyBnJfs62G3TXiZ3/mqMBqyMDqKAyQljDzg==
+"@voltz-protocol/v1-sdk@1.30.1":
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/@voltz-protocol/v1-sdk/-/v1-sdk-1.30.1.tgz#412409c8c9c228f45670fa54be8963e3c33dd438"
+  integrity sha512-gE3yzYB3ltMn04kKne34a8KFYe3u056KyIJmaxeI4HHZwqJb4eQfbLlU6IsqRYuTRZ+rjdAoQKn7tPQcwInSSA==
   dependencies:
     "@apollo/client" "^3.7.1"
     "@ethersproject/address" "^5.7.0"


### PR DESCRIPTION
# Title

Post S1 end fixes

## Description

Fix for leaderboard not loading, adapt subgraph query for high load of data.
Fix for OG badges claiming, add 1-day buffer from season end to badges awarded in old seasons.

## Amplify hosted environment link

## Notion link

https://www.notion.so/voltz/Post-Season-1-Claiming-Fixes-d33902a9112a42b7b21a03e3cf9ca81e

