### PR TITLE
Fix in position loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/react": "7.25.0",
     "@sentry/tracing": "7.25.0",
-    "@voltz-protocol/v1-sdk": "1.38.0",
+    "@voltz-protocol/v1-sdk": "1.39.0",
     "@walletconnect/ethereum-provider": "1.8.0",
     "@walletconnect/web3-provider": "1.8.0",
     "aws-amplify": "4.3.44",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/react": "7.25.0",
     "@sentry/tracing": "7.25.0",
-    "@voltz-protocol/v1-sdk": "1.39.0",
+    "@voltz-protocol/v1-sdk": "1.39.1",
     "@walletconnect/ethereum-provider": "1.8.0",
     "@walletconnect/web3-provider": "1.8.0",
     "aws-amplify": "4.3.44",

--- a/src/components/atomic/RouteLink/RouteLink.tsx
+++ b/src/components/atomic/RouteLink/RouteLink.tsx
@@ -1,5 +1,4 @@
 import { styled } from '@mui/material/styles';
-import React from 'react';
 import { Link, LinkProps } from 'react-router-dom';
 
 import { Agents } from '../../../contexts/AgentContext/types';

--- a/src/hooks/usePositions/usePositions.ts
+++ b/src/hooks/usePositions/usePositions.ts
@@ -28,17 +28,9 @@ export const usePositions = (agent: Agents): UsePositionsResult => {
 
   useEffect(() => {
     setMePositions([]);
-    console.log("console: changers:", agent, userAddress, !!aMMs, aMMsLoadedState, Date.now().valueOf());
     if (userAddress && aMMs && aMMs.length > 0 && aMMsLoadedState === 'succeeded' && agent) {
       setFetchLoading(true);
       setFetchError(false);
-
-      console.log("console: params", {
-        userWalletId: userAddress,
-        amms: aMMs,
-        subgraphURL: process.env.REACT_APP_SUBGRAPH_URL || '',
-        type: agent === Agents.LIQUIDITY_PROVIDER ? 'LP' : 'Trader',
-      });
 
       void getPositions({
         userWalletId: userAddress,

--- a/src/hooks/usePositions/usePositions.ts
+++ b/src/hooks/usePositions/usePositions.ts
@@ -8,7 +8,6 @@ import { updateTransactionAction } from '../../app/features/transactions';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { Agents } from '../../contexts/AgentContext/types';
 import { isBorrowingPosition } from '../../utilities/borrowAmm';
-import { useAgent } from '../useAgent';
 import { useWallet } from '../useWallet';
 
 type UsePositionsResult = {
@@ -18,8 +17,7 @@ type UsePositionsResult = {
   error: boolean;
 };
 
-export const usePositions = (): UsePositionsResult => {
-  const { agent } = useAgent();
+export const usePositions = (agent: Agents): UsePositionsResult => {
   const { account: userAddress } = useWallet();
   const dispatch = useAppDispatch();
   const aMMsLoadedState = useAppSelector((state) => state.aMMs.aMMsLoadedState);
@@ -30,9 +28,17 @@ export const usePositions = (): UsePositionsResult => {
 
   useEffect(() => {
     setMePositions([]);
-    if (userAddress && aMMsLoadedState === 'succeeded' && agent) {
+    console.log("console: changers:", agent, userAddress, !!aMMs, aMMsLoadedState, Date.now().valueOf());
+    if (userAddress && aMMs && aMMs.length > 0 && aMMsLoadedState === 'succeeded' && agent) {
       setFetchLoading(true);
       setFetchError(false);
+
+      console.log("console: params", {
+        userWalletId: userAddress,
+        amms: aMMs,
+        subgraphURL: process.env.REACT_APP_SUBGRAPH_URL || '',
+        type: agent === Agents.LIQUIDITY_PROVIDER ? 'LP' : 'Trader',
+      });
 
       void getPositions({
         userWalletId: userAddress,
@@ -48,7 +54,7 @@ export const usePositions = (): UsePositionsResult => {
         }
       });
     }
-  }, [agent, userAddress, !!aMMs, aMMsLoadedState]);
+  }, [userAddress, !!aMMs, aMMsLoadedState]);
 
   const unresolvedTransactions = useAppSelector(selectors.unresolvedTransactionsSelector);
   const shouldTryToCloseTransactions =

--- a/src/routes/FixedBorrower/ConnectedBorrowPositionTable/ConnectedBorrowPositionTable.tsx
+++ b/src/routes/FixedBorrower/ConnectedBorrowPositionTable/ConnectedBorrowPositionTable.tsx
@@ -8,7 +8,6 @@ import {
   BorrowPortfolioHeader,
   BorrowPortfolioHeaderProps,
 } from '../../../components/interface/BorrowPortfolioHeader/BorrowPortfolioHeader';
-import { Agents } from '../../../contexts/AgentContext/types';
 import { useAMMs } from '../../../hooks/useAMMs';
 import { useWallet } from '../../../hooks/useWallet';
 import { SystemStyleObject, Theme } from '../../../theme';
@@ -17,7 +16,6 @@ import { getTotalFixedDebt, getTotalVariableDebt } from './services';
 
 export type ConnectedBorrowAMMTableProps = {
   onSelectItem: (item: BorrowAMM) => void;
-  agent: Agents;
   borrowPositions: Position[];
   errorPositions: boolean;
   loadingPositions: boolean;

--- a/src/routes/FixedBorrower/FixedBorrower.tsx
+++ b/src/routes/FixedBorrower/FixedBorrower.tsx
@@ -90,7 +90,6 @@ export const FixedBorrower: React.FunctionComponent = () => {
       {renderMode === 'borrow-positions' && (
         <Box sx={{ backdropFilter: 'blur(8px)', height: '100%', paddingBottom: '200px' }}>
           <ConnectedBorrowPositionTable
-            agent={Agents.VARIABLE_TRADER}
             borrowPositions={borrowPositions}
             errorPositions={errorPositions}
             loadingPositions={loadingPositions}

--- a/src/routes/FixedBorrower/FixedBorrower.tsx
+++ b/src/routes/FixedBorrower/FixedBorrower.tsx
@@ -22,7 +22,11 @@ export const FixedBorrower: React.FunctionComponent = () => {
   const [position, setPosition] = useState<Position>();
   const { onChangeAgent } = useAgent();
 
-  const { borrowPositions, loading: loadingPositions, error: errorPositions } = usePositions(Agents.VARIABLE_TRADER);
+  const {
+    borrowPositions,
+    loading: loadingPositions,
+    error: errorPositions,
+  } = usePositions(Agents.VARIABLE_TRADER);
   const { account } = useWallet();
 
   const renderMode = getRenderMode(isForm);

--- a/src/routes/FixedBorrower/FixedBorrower.tsx
+++ b/src/routes/FixedBorrower/FixedBorrower.tsx
@@ -22,7 +22,7 @@ export const FixedBorrower: React.FunctionComponent = () => {
   const [position, setPosition] = useState<Position>();
   const { onChangeAgent } = useAgent();
 
-  const { borrowPositions, loading: loadingPositions, error: errorPositions } = usePositions();
+  const { borrowPositions, loading: loadingPositions, error: errorPositions } = usePositions(Agents.VARIABLE_TRADER);
   const { account } = useWallet();
 
   const renderMode = getRenderMode(isForm);

--- a/src/routes/LPPools/LPPools.tsx
+++ b/src/routes/LPPools/LPPools.tsx
@@ -31,7 +31,7 @@ export const LPPools: React.FunctionComponent = () => {
 
   const { onChangeAgent } = useAgent();
   const { key } = useLocation();
-  const { positionsByAgentGroup } = usePositions();
+  const { positionsByAgentGroup } = usePositions(Agents.LIQUIDITY_PROVIDER);
   const { account } = useWallet();
 
   const renderMode = formMode ? 'form' : 'pools';

--- a/src/routes/LPPortfolio/LPPositions/ConnectedPositionTable/ConnectedPositionTable.tsx
+++ b/src/routes/LPPortfolio/LPPositions/ConnectedPositionTable/ConnectedPositionTable.tsx
@@ -23,7 +23,6 @@ export type ConnectedPositionTableProps = {
   loadingPositions: boolean;
   errorPositions: boolean;
   handleCompletedSettling: () => void;
-  agent: Agents;
 };
 
 export const ConnectedPositionTable: React.FunctionComponent<ConnectedPositionTableProps> = ({
@@ -31,7 +30,6 @@ export const ConnectedPositionTable: React.FunctionComponent<ConnectedPositionTa
   positions,
   loadingPositions,
   handleCompletedSettling,
-  agent,
 }) => {
   const { status } = useWallet();
   const [positionStatus, setPositionStatus] = useState<PositionStatus>('open');

--- a/src/routes/LPPortfolio/LPPositions/LPPositions.tsx
+++ b/src/routes/LPPortfolio/LPPositions/LPPositions.tsx
@@ -91,7 +91,6 @@ export const LPPositions: React.FunctionComponent<{
     <>
       {renderMode === 'portfolio' && (
         <ConnectedPositionTable
-          agent={Agents.LIQUIDITY_PROVIDER}
           errorPositions={errorPositions}
           handleCompletedSettling={handleCompletedSettling}
           loadingPositions={loadingPositions}

--- a/src/routes/LPPortfolio/LPPositions/LPPositions.tsx
+++ b/src/routes/LPPortfolio/LPPositions/LPPositions.tsx
@@ -34,7 +34,7 @@ export const LPPositions: React.FunctionComponent<{
     positionsByAgentGroup,
     loading: loadingPositions,
     error: errorPositions,
-  } = usePositions();
+  } = usePositions(Agents.LIQUIDITY_PROVIDER);
   const { account } = useWallet();
 
   const renderMode = formMode ? 'form' : 'portfolio';

--- a/src/routes/TraderPools/TraderPools.tsx
+++ b/src/routes/TraderPools/TraderPools.tsx
@@ -26,7 +26,7 @@ export const TraderPools: React.FunctionComponent = () => {
 
   const { onChangeAgent } = useAgent();
   const { key } = useLocation();
-  const { positionsByAgentGroup } = usePositions();
+  const { positionsByAgentGroup } = usePositions(Agents.FIXED_TRADER);
   const { account } = useWallet();
 
   const renderMode = formMode ? 'form' : 'pools';

--- a/src/routes/TraderPortfolio/ConnectedPositionTable/ConnectedPositionTable.tsx
+++ b/src/routes/TraderPortfolio/ConnectedPositionTable/ConnectedPositionTable.tsx
@@ -19,7 +19,6 @@ import { PositionTable } from './PositionTable/PositionTable';
 
 export type ConnectedPositionTableProps = {
   onSelectItem: (item: Position, mode: 'margin' | 'liquidity' | 'rollover' | 'notional') => void;
-  agent: Agents;
   positions: Position[];
   loadingPositions: boolean;
   errorPositions: boolean;
@@ -28,7 +27,6 @@ export type ConnectedPositionTableProps = {
 
 export const ConnectedPositionTable: React.FunctionComponent<ConnectedPositionTableProps> = ({
   onSelectItem,
-  agent,
   positions,
   loadingPositions,
   errorPositions,
@@ -49,7 +47,7 @@ export const ConnectedPositionTable: React.FunctionComponent<ConnectedPositionTa
         notional: 0,
         margin: 0,
         ammId: positionAmm.id,
-        agent,
+        agent: Agents.FIXED_TRADER,
         fixedLow: position.fixedRateLower.toNumber(),
         fixedHigh: position.fixedRateUpper.toNumber(),
       };
@@ -60,7 +58,7 @@ export const ConnectedPositionTable: React.FunctionComponent<ConnectedPositionTa
       });
       dispatch(settlePositionAction);
     },
-    [dispatch, agent],
+    [dispatch],
   );
 
   const handleTransactionFinished = () => {
@@ -93,9 +91,7 @@ export const ConnectedPositionTable: React.FunctionComponent<ConnectedPositionTa
     return (
       <Panel sx={{ width: '100%', textAlign: 'center' }} variant="main">
         <RouteLink
-          to={
-            agent === Agents.LIQUIDITY_PROVIDER ? `/${routes.LP_POOLS}` : `/${routes.TRADER_POOLS}`
-          }
+          to={`/${routes.TRADER_POOLS}`}
         >
           OPEN YOUR FIRST POSITION
         </RouteLink>
@@ -106,12 +102,7 @@ export const ConnectedPositionTable: React.FunctionComponent<ConnectedPositionTa
   const renderPendingTransaction = () => {
     if (!positionToSettle) return null;
 
-    let netWithdraw = undefined;
-    if (agent === Agents.LIQUIDITY_PROVIDER) {
-      netWithdraw = positionToSettle.position.margin + positionToSettle.position.settlementCashflow;
-    } else {
-      netWithdraw = positionToSettle.position.margin + positionToSettle.position.settlementCashflow;
-    }
+    const netWithdraw = positionToSettle.position.margin + positionToSettle.position.settlementCashflow;
 
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center' }}>

--- a/src/routes/TraderPortfolio/ConnectedPositionTable/ConnectedPositionTable.tsx
+++ b/src/routes/TraderPortfolio/ConnectedPositionTable/ConnectedPositionTable.tsx
@@ -90,11 +90,7 @@ export const ConnectedPositionTable: React.FunctionComponent<ConnectedPositionTa
   const renderNoPositions = () => {
     return (
       <Panel sx={{ width: '100%', textAlign: 'center' }} variant="main">
-        <RouteLink
-          to={`/${routes.TRADER_POOLS}`}
-        >
-          OPEN YOUR FIRST POSITION
-        </RouteLink>
+        <RouteLink to={`/${routes.TRADER_POOLS}`}>OPEN YOUR FIRST POSITION</RouteLink>
       </Panel>
     );
   };
@@ -102,7 +98,8 @@ export const ConnectedPositionTable: React.FunctionComponent<ConnectedPositionTa
   const renderPendingTransaction = () => {
     if (!positionToSettle) return null;
 
-    const netWithdraw = positionToSettle.position.margin + positionToSettle.position.settlementCashflow;
+    const netWithdraw =
+      positionToSettle.position.margin + positionToSettle.position.settlementCashflow;
 
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center' }}>

--- a/src/routes/TraderPortfolio/ConnectedPositionTable/PortfolioHeader/PorfolioHeaderInfo.tsx
+++ b/src/routes/TraderPortfolio/ConnectedPositionTable/PortfolioHeader/PorfolioHeaderInfo.tsx
@@ -83,7 +83,6 @@ export const PortfolioHeaderInfo = ({
           </PortfolioHeaderBox>
         </PortfolioHeaderValue>
       </ListItem>
-
     </List>
   );
 };

--- a/src/routes/TraderPortfolio/ConnectedPositionTable/PortfolioHeader/PorfolioHeaderInfo.tsx
+++ b/src/routes/TraderPortfolio/ConnectedPositionTable/PortfolioHeader/PorfolioHeaderInfo.tsx
@@ -3,8 +3,6 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import isUndefined from 'lodash.isundefined';
 
-import { Agents } from '../../../../contexts/AgentContext/types';
-import { useAgent } from '../../../../hooks/useAgent';
 import { colors, SystemStyleObject, Theme } from '../../../../theme';
 import { formatCurrency, formatNumber } from '../../../../utilities/number';
 import { PortfolioHeaderBox } from './PortfolioHeaderBox';
@@ -36,7 +34,6 @@ export const PortfolioHeaderInfo = ({
   netRatePaying,
   netRateReceiving,
 }: PortfolioHeaderInfoProps) => {
-  const { agent } = useAgent();
   const getNetMarginLabel = () => (
     <>
       Net margin
@@ -70,34 +67,23 @@ export const PortfolioHeaderInfo = ({
           </PortfolioHeaderBox>
         </PortfolioHeaderValue>
       </ListItem>
-      {!(agent === Agents.LIQUIDITY_PROVIDER) && (
-        <ListItem sx={listItemStyles}>
-          <PortfolioHeaderValue label="Net rate receiving">
-            <PortfolioHeaderBox>
-              {isUndefined(netRateReceiving) && <>Loading...</>}
-              {!isUndefined(netRateReceiving) && <>{formatNumber(netRateReceiving)} %</>}
-            </PortfolioHeaderBox>
-          </PortfolioHeaderValue>
-        </ListItem>
-      )}
-      {!(agent === Agents.LIQUIDITY_PROVIDER) && (
-        <ListItem sx={listItemStyles}>
-          <PortfolioHeaderValue label="Net rate paying">
-            <PortfolioHeaderBox>
-              {isUndefined(netRatePaying) && <>Loading...</>}
-              {!isUndefined(netRatePaying) && <>{formatNumber(netRatePaying)} %</>}
-            </PortfolioHeaderBox>
-          </PortfolioHeaderValue>
-        </ListItem>
-      )}
-      {agent === Agents.LIQUIDITY_PROVIDER && (
-        <ListItem sx={listItemStyles}>
-          <PortfolioHeaderValue label="Fees APY">
-            <PortfolioHeaderBox>s00n</PortfolioHeaderBox>
-            {/* <PortfolioHeaderBox>{formatNumber(feesApy)} %</PortfolioHeaderBox> */}
-          </PortfolioHeaderValue>
-        </ListItem>
-      )}
+      <ListItem sx={listItemStyles}>
+        <PortfolioHeaderValue label="Net rate receiving">
+          <PortfolioHeaderBox>
+            {isUndefined(netRateReceiving) && <>Loading...</>}
+            {!isUndefined(netRateReceiving) && <>{formatNumber(netRateReceiving)} %</>}
+          </PortfolioHeaderBox>
+        </PortfolioHeaderValue>
+      </ListItem>
+      <ListItem sx={listItemStyles}>
+        <PortfolioHeaderValue label="Net rate paying">
+          <PortfolioHeaderBox>
+            {isUndefined(netRatePaying) && <>Loading...</>}
+            {!isUndefined(netRatePaying) && <>{formatNumber(netRatePaying)} %</>}
+          </PortfolioHeaderBox>
+        </PortfolioHeaderValue>
+      </ListItem>
+
     </List>
   );
 };

--- a/src/routes/TraderPortfolio/ConnectedPositionTable/PositionTable/PositionTable.tsx
+++ b/src/routes/TraderPortfolio/ConnectedPositionTable/PositionTable/PositionTable.tsx
@@ -141,11 +141,7 @@ export const PositionTable: React.FunctionComponent<PositionTableProps> = ({
                 <Table size="medium" sx={{ ...commonOverrides }}>
                   <TableBody>
                     <AMMProvider amm={pos.amm}>
-                      <PositionTableRow
-                        key={pos.id}
-                        index={index}
-                        position={pos}
-                      />
+                      <PositionTableRow key={pos.id} index={index} position={pos} />
                     </AMMProvider>
                   </TableBody>
                 </Table>

--- a/src/routes/TraderPortfolio/ConnectedPositionTable/PositionTable/PositionTable.tsx
+++ b/src/routes/TraderPortfolio/ConnectedPositionTable/PositionTable/PositionTable.tsx
@@ -7,9 +7,7 @@ import { Position } from '@voltz-protocol/v1-sdk';
 import React from 'react';
 
 import { Panel } from '../../../../components/atomic/Panel/Panel';
-import { Agents } from '../../../../contexts/AgentContext/types';
 import { AMMProvider } from '../../../../contexts/AMMContext/AMMContext';
-import { useAgent } from '../../../../hooks/useAgent';
 import { useAMMs } from '../../../../hooks/useAMMs';
 import { getConfig } from '../../../../hooks/voltz-config/config';
 import { colors, SystemStyleObject, Theme } from '../../../../theme';
@@ -31,7 +29,6 @@ export const PositionTable: React.FunctionComponent<PositionTableProps> = ({
   onSettle,
 }) => {
   const { aMMs } = useAMMs();
-  const { agent } = useAgent();
 
   const commonOverrides: SystemStyleObject<Theme> = {
     '& .MuiTableCell-root': {
@@ -113,14 +110,8 @@ export const PositionTable: React.FunctionComponent<PositionTableProps> = ({
             >
               <PositionTableHead
                 beforeMaturity={!pos.isPoolMatured}
-                currencyCode="USD"
-                currencySymbol="$"
-                fees={pos.fees}
-                feesPositive={true}
-                fixedApr={pos.poolAPR}
-                fixedRateHealthFactor={pos.fixedRateHealthFactor}
                 gaButtonId={getRowButtonId(
-                  agent === Agents.LIQUIDITY_PROVIDER,
+                  false,
                   pos.amm.protocol,
                   isBorrowing(pos.amm.rateOracle.protocolId),
                 )}
@@ -133,7 +124,7 @@ export const PositionTable: React.FunctionComponent<PositionTableProps> = ({
                 rolloverAvailable={rolloverAvailable}
                 onRollover={() => handleSelectRow(index, 'rollover')}
                 onSelect={
-                  agent === Agents.LIQUIDITY_PROVIDER || closeToMaturity
+                  closeToMaturity
                     ? undefined
                     : (mode: 'margin' | 'liquidity' | 'notional') => handleSelectRow(index, mode)
                 }
@@ -154,9 +145,6 @@ export const PositionTable: React.FunctionComponent<PositionTableProps> = ({
                         key={pos.id}
                         index={index}
                         position={pos}
-                        onSelect={(mode: 'margin' | 'liquidity' | 'notional') =>
-                          handleSelectRow(index, mode)
-                        }
                       />
                     </AMMProvider>
                   </TableBody>

--- a/src/routes/TraderPortfolio/ConnectedPositionTable/PositionTable/components/PositionTableHead/PositionTableHead.tsx
+++ b/src/routes/TraderPortfolio/ConnectedPositionTable/PositionTable/components/PositionTableHead/PositionTableHead.tsx
@@ -7,23 +7,16 @@ import {
   getPositionBadgeVariant,
   PositionBadge,
 } from '../../../../../../components/atomic/PositionBadge/PositionBadge';
-import { Typography } from '../../../../../../components/atomic/Typography/Typography';
 import { BulletLabel } from '../../../../../../components/composite/BulletLabel/BulletLabel';
 import {
   getHealthTextColor,
   HealthFactorText,
 } from '../../../../../../components/composite/HealthFactorText/HealthFactorText';
-import { Agents } from '../../../../../../contexts/AgentContext/types';
-import { useAgent } from '../../../../../../hooks/useAgent';
-import { colors, SystemStyleObject, Theme } from '../../../../../../theme';
-import { formatCurrency, formatNumber } from '../../../../../../utilities/number';
+import { SystemStyleObject, Theme } from '../../../../../../theme';
 import { ReactComponent as EditIcon } from './editPosition.svg';
 
 export type PositionTableHeadProps = {
   poolTraderWithdrawable: boolean;
-  currencyCode: string;
-  currencySymbol: string;
-  feesPositive: boolean;
   isSettled: boolean;
   positionType: number;
   onRollover: () => void;
@@ -33,9 +26,6 @@ export type PositionTableHeadProps = {
   onSelect?: (mode: 'margin' | 'liquidity' | 'notional') => void;
   beforeMaturity?: boolean;
   healthFactor?: number;
-  fixedRateHealthFactor?: number;
-  fixedApr?: number;
-  fees?: number;
 };
 
 const containerStyles: SystemStyleObject<Theme> = {
@@ -45,19 +35,8 @@ const containerStyles: SystemStyleObject<Theme> = {
   padding: (theme) => `${theme.spacing(4)} 0`,
 };
 
-const labelStyles: SystemStyleObject<Theme> = {
-  fontSize: '14px',
-  lineHeight: '1',
-  textTransform: 'uppercase',
-  display: 'flex',
-  verticalAlign: 'middle',
-};
-
 export const PositionTableHead: React.FunctionComponent<PositionTableHeadProps> = ({
   poolTraderWithdrawable,
-  currencyCode = '',
-  currencySymbol = '',
-  feesPositive = true,
   isSettled,
   positionType,
   onRollover,
@@ -67,18 +46,7 @@ export const PositionTableHead: React.FunctionComponent<PositionTableHeadProps> 
   onSelect,
   beforeMaturity,
   healthFactor,
-  fixedRateHealthFactor,
-  fixedApr,
-  fees: feesProp,
 }) => {
-  const { agent } = useAgent();
-  const currentFixedRate = agent === Agents.LIQUIDITY_PROVIDER ? fixedApr : undefined;
-  const fees = agent === Agents.LIQUIDITY_PROVIDER ? feesProp : undefined;
-
-  const getTextColor = (positive: boolean) => {
-    return positive ? colors.vzCustomGreen1.base : colors.vzCustomRed1.base;
-  };
-
   const handleEditNotional = () => {
     onSelect && onSelect('notional');
   };
@@ -87,42 +55,9 @@ export const PositionTableHead: React.FunctionComponent<PositionTableHeadProps> 
     <Box sx={containerStyles}>
       <Box sx={{ display: 'flex' }}>
         <PositionBadge variant={getPositionBadgeVariant(positionType)} />
-
-        {!isUndefined(fees) && (
-          <Box
-            sx={{
-              padding: (theme) => `${theme.spacing(1)} ${theme.spacing(2)}`,
-              marginLeft: (theme) => theme.spacing(4),
-            }}
-          >
-            <Typography sx={{ ...labelStyles }} variant="body2">
-              Fees:
-              <Box component="span" sx={{ color: getTextColor(feesPositive) }}>
-                {' '}
-                {!feesPositive && '-'}
-                {currencySymbol}
-                {formatCurrency(Math.abs(fees))} {currencyCode}
-              </Box>
-            </Typography>
-          </Box>
-        )}
       </Box>
 
       <Box sx={{ display: 'flex' }}>
-        {beforeMaturity && !isUndefined(currentFixedRate) && !isUndefined(healthFactor) && (
-          <Box
-            sx={{
-              padding: (theme) => `${theme.spacing(1)} ${theme.spacing(2)}`,
-              marginLeft: (theme) => theme.spacing(2),
-            }}
-          >
-            <BulletLabel
-              sx={{ color: getHealthTextColor(fixedRateHealthFactor) }}
-              text={<>Current fixed rate: {formatNumber(currentFixedRate)}%</>}
-            />
-          </Box>
-        )}
-
         {beforeMaturity && !isUndefined(healthFactor) && (
           <Box
             sx={{

--- a/src/routes/TraderPortfolio/ConnectedPositionTable/PositionTable/components/PositionTableRow/PositionTableRow.tsx
+++ b/src/routes/TraderPortfolio/ConnectedPositionTable/PositionTable/components/PositionTableRow/PositionTableRow.tsx
@@ -1,66 +1,39 @@
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
 import { Position } from '@voltz-protocol/v1-sdk';
-import isNumber from 'lodash.isnumber';
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import { Typography } from '../../../../../../components/atomic/Typography/Typography';
 import { MaturityInformation } from '../../../../../../components/composite/MaturityInformation/MaturityInformation';
 import { PoolField } from '../../../../../../components/composite/PoolField/PoolField';
 import { Agents } from '../../../../../../contexts/AgentContext/types';
-import { useAMMContext } from '../../../../../../contexts/AMMContext/AMMContext';
-import { useAgent } from '../../../../../../hooks/useAgent';
 import { SystemStyleObject, Theme } from '../../../../../../theme';
 import { isBorrowing } from '../../../../../../utilities/amm';
-import { formatNumber } from '../../../../../../utilities/number';
-import { lpLabels, traderLabels } from '../../constants';
-import { AccruedRates, CurrentMargin, FixedAPR, Notional } from './components';
+import { traderLabels } from '../../constants';
+import { AccruedRates, CurrentMargin, Notional } from './components';
 
 export type PositionTableRowProps = {
   position: Position;
   index: number;
-  onSelect: (mode: 'margin' | 'liquidity' | 'notional') => void;
 };
 
 export const PositionTableRow: React.FunctionComponent<PositionTableRowProps> = ({
   position,
   index,
-  onSelect,
 }) => {
-  const { agent } = useAgent();
-  const labels = agent === Agents.LIQUIDITY_PROVIDER ? lpLabels : traderLabels;
-
-  const { fixedApr } = useAMMContext();
-  const { result: resultFixedApr, call: callFixedApr } = fixedApr;
-
-  useEffect(() => {
-    callFixedApr();
-  }, [callFixedApr]);
+  const labels = traderLabels;
 
   const typeStyleOverrides: SystemStyleObject<Theme> = {
     backgroundColor: `secondary.darken050`, // this affects the colour of the positions rows in the LP positions
     borderRadius: 2,
   };
 
-  const handleEditMargin = () => {
-    onSelect('margin');
-  };
-
-  const handleEditLPNotional = () => {
-    onSelect('liquidity');
-  };
-
-  const renderTableCell = (field: string, label: string) => {
+  const renderTableCell = (field: string) => {
     const underlyingTokenName = position.amm.underlyingToken.name; // Introduced this so margin and notional show the correct underlying token unit e.g. Eth not stEth, USDC not aUSDC
 
     if (field === 'accruedRates') {
       return (
         <AccruedRates payingRate={position.payingRate} receivingRate={position.receivingRate} />
       );
-    }
-
-    if (field === 'fixedApr') {
-      return <FixedAPR fixedApr={isNumber(resultFixedApr) ? resultFixedApr : undefined} />;
     }
 
     if (field === 'margin') {
@@ -71,7 +44,6 @@ export const PositionTableRow: React.FunctionComponent<PositionTableRowProps> = 
           margin={position.margin}
           marginEdit={true}
           token={underlyingTokenName || ''}
-          onSelect={agent === Agents.LIQUIDITY_PROVIDER ? handleEditMargin : undefined}
         />
       );
     }
@@ -91,7 +63,6 @@ export const PositionTableRow: React.FunctionComponent<PositionTableRowProps> = 
         <Notional
           notional={position.notional}
           token={underlyingTokenName || ''}
-          onEdit={agent === Agents.LIQUIDITY_PROVIDER ? handleEditLPNotional : undefined}
         />
       );
     }
@@ -99,19 +70,10 @@ export const PositionTableRow: React.FunctionComponent<PositionTableRowProps> = 
     if (field === 'pool') {
       return (
         <PoolField
-          agent={agent}
+          agent={Agents.FIXED_TRADER}
           isBorrowing={isBorrowing(position.amm.rateOracle.protocolId)}
           protocol={position.amm.protocol}
         />
-      );
-    }
-
-    if (field === 'rateRange') {
-      return (
-        <Typography label={label} variant="h5">
-          {formatNumber(position.fixedRateLower.toNumber())}% /{' '}
-          {formatNumber(position.fixedRateUpper.toNumber())}%
-        </Typography>
       );
     }
 
@@ -120,8 +82,8 @@ export const PositionTableRow: React.FunctionComponent<PositionTableRowProps> = 
 
   return (
     <TableRow key={index} sx={{ ...typeStyleOverrides }}>
-      {labels.map(([field, label]) => {
-        return <TableCell key={field}>{renderTableCell(field, label)}</TableCell>;
+      {labels.map(([field]) => {
+        return <TableCell key={field}>{renderTableCell(field)}</TableCell>;
       })}
     </TableRow>
   );

--- a/src/routes/TraderPortfolio/ConnectedPositionTable/PositionTable/components/PositionTableRow/PositionTableRow.tsx
+++ b/src/routes/TraderPortfolio/ConnectedPositionTable/PositionTable/components/PositionTableRow/PositionTableRow.tsx
@@ -59,12 +59,7 @@ export const PositionTableRow: React.FunctionComponent<PositionTableRowProps> = 
     }
 
     if (field === 'notional') {
-      return (
-        <Notional
-          notional={position.notional}
-          token={underlyingTokenName || ''}
-        />
-      );
+      return <Notional notional={position.notional} token={underlyingTokenName || ''} />;
     }
 
     if (field === 'pool') {

--- a/src/routes/TraderPortfolio/TraderPortfolio.tsx
+++ b/src/routes/TraderPortfolio/TraderPortfolio.tsx
@@ -30,7 +30,7 @@ export const TraderPortfolio: React.FunctionComponent = () => {
     positionsByAgentGroup,
     loading: loadingPositions,
     error: errorPositions,
-  } = usePositions();
+  } = usePositions(Agents.FIXED_TRADER);
   const { account } = useWallet();
 
   const renderMode = formMode ? 'form' : 'portfolio';

--- a/src/routes/TraderPortfolio/TraderPortfolio.tsx
+++ b/src/routes/TraderPortfolio/TraderPortfolio.tsx
@@ -87,7 +87,6 @@ export const TraderPortfolio: React.FunctionComponent = () => {
     <>
       {renderMode === 'portfolio' && (
         <ConnectedPositionTable
-          agent={Agents.FIXED_TRADER}
           errorPositions={errorPositions}
           handleCompletedSettling={handleCompletedSettling}
           loadingPositions={loadingPositions}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7040,10 +7040,10 @@
     graphql-request "5.0.0"
     lodash.isundefined "3.0.1"
 
-"@voltz-protocol/v1-sdk@1.38.0":
-  version "1.38.0"
-  resolved "https://registry.yarnpkg.com/@voltz-protocol/v1-sdk/-/v1-sdk-1.38.0.tgz#f4d23be013d84c19a969bfd3bd91a990b8312604"
-  integrity sha512-eIE3nxZ3b3wtVjYrDfNS/KJPrrTKtwopdtkFhk9/AHXfO7g7+PlyWi5Hf6ha0fG8EDZcez/Nj+JY572Y462YsQ==
+"@voltz-protocol/v1-sdk@1.39.0":
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/@voltz-protocol/v1-sdk/-/v1-sdk-1.39.0.tgz#a42d9906860a834cea16e0cd398de1728c3cd077"
+  integrity sha512-R7qPW6xyyzHtKTsDk9ErKAhW/TmyqQHg0heyCCHssLr7AN6VJRTckSj8rTCZEuCrTSRBaOtGLyahe7QiKc/nxA==
   dependencies:
     "@ethersproject/address" "^5.7.0"
     "@metamask/detect-provider" "^1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7040,10 +7040,10 @@
     graphql-request "5.0.0"
     lodash.isundefined "3.0.1"
 
-"@voltz-protocol/v1-sdk@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@voltz-protocol/v1-sdk/-/v1-sdk-1.39.0.tgz#a42d9906860a834cea16e0cd398de1728c3cd077"
-  integrity sha512-R7qPW6xyyzHtKTsDk9ErKAhW/TmyqQHg0heyCCHssLr7AN6VJRTckSj8rTCZEuCrTSRBaOtGLyahe7QiKc/nxA==
+"@voltz-protocol/v1-sdk@1.39.1":
+  version "1.39.1"
+  resolved "https://registry.yarnpkg.com/@voltz-protocol/v1-sdk/-/v1-sdk-1.39.1.tgz#c0a4dc70226a17936258209b2e21567350658eb8"
+  integrity sha512-VRcC4lS3OPVefuv3Cf46106AwjzjqYh5FwJXqvL97mRkSCv43DPMhxhR0wScZvjED3QpLAg/EMpgUO9b+jM9sg==
   dependencies:
     "@ethersproject/address" "^5.7.0"
     "@metamask/detect-provider" "^1.2.0"


### PR DESCRIPTION
# Title

Fix in position loading

## Description

There was an issue in the position pages:
  - if you were Trader Pools, the usePositions() context was initialised; however, if you then click on LP Positions, another usePositions() context is initialised. The issue is that two concurrent calls getPositions() get called, one with the old agent, FIXED TAKER, and one with the new agent LP. If the call with LP finished first, then the call with FIXED TAKER overrides the positions and there'll be Trader Positions on the LP page.
  - as a solution to the above, I removed useAgent() use in all places where we knew what agent to use (i.e. LP Positions should use LP, etc.)
  - also fixed an issue with ETH withdraw that I found on the way (withdrawal was done in ETH rather than in WETH but impossible to withdraw ETH)

## Amplify hosted environment link

https://feat-fix-in-position-loading.d2f2fhja7tsifl.amplifyapp.com/

