### PR TITLE
chore: bump sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@reduxjs/toolkit": "1.9.0",
     "@sentry/react": "7.25.0",
     "@sentry/tracing": "7.25.0",
-    "@voltz-protocol/v1-sdk": "1.57.0",
+    "@voltz-protocol/v1-sdk": "1.57.2",
     "@walletconnect/ethereum-provider": "1.8.0",
     "@walletconnect/web3-provider": "1.8.0",
     "add": "^2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7027,10 +7027,10 @@
     graphql-request "5.0.0"
     lodash.isundefined "3.0.1"
 
-"@voltz-protocol/v1-sdk@1.57.0":
-  version "1.57.0"
-  resolved "https://registry.yarnpkg.com/@voltz-protocol/v1-sdk/-/v1-sdk-1.57.0.tgz#bfda247177ce39b96657e1802dd6b5c746dfb65c"
-  integrity sha512-HbFA8JshGvsQUh+J5pys7JbSrcwZEK+gtXFpXziV9Q9hkpoyvn7srb7ZAgyIGoxIYdBwQXYeaeBAGtUaQ1FF/A==
+"@voltz-protocol/v1-sdk@1.57.2":
+  version "1.57.2"
+  resolved "https://registry.yarnpkg.com/@voltz-protocol/v1-sdk/-/v1-sdk-1.57.2.tgz#4cf42e36fffa1474e39456b648e1a150cd49554c"
+  integrity sha512-fIgfLyfPER3V+Vzv1xF+PhtoPnnWTyURu4M8APzgSPoHi7Ka+ZOcfULmzIDg28bKfrPb78zz75Ty/ZBCwDpjrQ==
   dependencies:
     "@ethersproject/address" "^5.7.0"
     "@metamask/detect-provider" "^1.2.0"


### PR DESCRIPTION
# Title

Bump SDK with config for aUSDC v6 (rolled over from aUSDC v4)
